### PR TITLE
Show loader upon submit

### DIFF
--- a/src/components/auth-card.tsx
+++ b/src/components/auth-card.tsx
@@ -92,6 +92,7 @@ export const defaultLocalization = {
     reset_password_email: "Check your email for the password reset link",
     magic_link_email: "Check your email for the magic link",
     password_updated: "Password updated",
+    loading: "Loading",
     error: "Error",
     alert: "Alert",
     or_continue_with: "Or continue with",
@@ -686,7 +687,12 @@ export function AuthCard({
                                 onClick={() => setView(view == "magic-link" ? "login" : "magic-link")}
                                 disabled={!["signup", "login", "magic-link"].includes(view!)}
                             >
-                                {view == "magic-link" ? <LockIcon /> : <MailIcon />}
+                                {loading ? (
+                                    <Loader2 className="animate-spin" />
+                                ) : (
+                                    view == "magic-link" ? <LockIcon /> : <MailIcon />
+                                )}
+                                
                                 {localization.provider_prefix}
                                 {" "}
                                 {view == "magic-link" ? localization.password_provider : localization.magic_link_provider}
@@ -721,7 +727,12 @@ export function AuthCard({
                                 }}
                                 disabled={!["login", "magic-link"].includes(view!)}
                             >
-                                <Key />
+                                {loading ? (
+                                    <Loader2 className="animate-spin" />
+                                ) : (
+                                    <Key />
+                                )}
+
                                 {localization.provider_prefix}
                                 {" "}
                                 {localization.passkey_provider}
@@ -768,13 +779,17 @@ export function AuthCard({
                                             }
                                         }}
                                     >
-                                        {socialProvider.icon}
+                                        {loading ? (
+                                            <Loader2 className="animate-spin" />
+                                        ) : (
+                                            socialProvider.icon
+                                        )}
 
                                         {socialLayout == "vertical" && (
                                             <>
                                                 {localization.provider_prefix}
                                                 {" "}
-                                                {socialProvider.name}
+                                                {loading ? localization.loading : socialProvider.name}
                                             </>
                                         )}
                                     </Button>


### PR DESCRIPTION
Liked your project a lot and decided to use it in a project. The first thing I have noticed is the loading spinner is missing upon submitting the form. Not sure if this is what you prefer but I always find it a good user feedback to show a loading spinner or some sort of status upon submitting a form in the in-between moment.

So, this PR adds a loading spinner and loading text upon submitting the auth form.

Note: I couldn't test it since you are using a [custom version of better auth from your local disk](https://github.com/daveyplate/better-auth-ui/blob/aa548b9bd3778e8d0edd2fdf810d8423982934c1/package.json#L36). So, I am blindly submitting this PR. It might break stuff. So, please feel free to take a brief look at it, make the necessary changes (if needed) or discard if it's not up to the mark 🙏
