### PR TITLE
revert change from LinkComponent in docs for AuthUIProvier prop

### DIFF
--- a/docs/content/docs/advanced/custom-auth-paths.mdx
+++ b/docs/content/docs/advanced/custom-auth-paths.mdx
@@ -26,7 +26,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
             navigate={router.push}
             replace={router.replace}
             onSessionChange={() => router.refresh()}
-            Link={Link}
+            LinkComponent={Link}
             viewPaths={{
                 signIn: "login",
                 signOut: "logout",

--- a/docs/content/docs/advanced/custom-settings.mdx
+++ b/docs/content/docs/advanced/custom-settings.mdx
@@ -40,7 +40,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
             replace={router.replace}
             onSessionChange={() => router.refresh()}
             settingsUrl="/dashboard/settings" // Your custom settings route
-            Link={Link}
+            LinkComponent={Link}
         >
             {children}
         </AuthUIProvider>

--- a/docs/content/docs/advanced/localization.mdx
+++ b/docs/content/docs/advanced/localization.mdx
@@ -30,7 +30,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
             navigate={router.push}
             replace={router.replace}
             onSessionChange={() => router.refresh()}
-            Link={Link}
+            LinkComponent={Link}
             localization={{
                 signIn: "Log in",
                 signInDescription: "Use your email and password to log in.",

--- a/docs/content/docs/components/auth-ui-provider.mdx
+++ b/docs/content/docs/components/auth-ui-provider.mdx
@@ -23,7 +23,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
       navigate={router.push}
       replace={router.replace}
       onSessionChange={() => router.refresh()}
-      Link={Link}
+      LinkComponent={Link}
     >
       {children}
     </AuthUIProvider>
@@ -75,7 +75,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             return data.url
           }}
           settingsUrl="/dashboard/settings"
-          Link={Link}
+          LinkComponent={Link}
         >
           {children}
         </AuthUIProvider>

--- a/docs/content/docs/components/settings-cards.mdx
+++ b/docs/content/docs/components/settings-cards.mdx
@@ -33,7 +33,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
             replace={router.replace}
             onSessionChange={() => router.refresh()}
             settingsUrl="/dashboard/settings"  // Your custom settings page URL
-            Link={Link}
+            LinkComponent={Link}
         >
             {children}
         </AuthUIProvider>

--- a/docs/content/docs/components/update-avatar-card.mdx
+++ b/docs/content/docs/components/update-avatar-card.mdx
@@ -55,7 +55,7 @@ export const Providers = ({ children }: { children: React.ReactNode }) => {
                 const { data } = await res.json()
                 return data.url
             }}
-            Link={Link}
+            LinkComponent={Link}
         >
             {children}
         </AuthUIProvider>

--- a/docs/content/docs/integrations/better-auth-tanstack.mdx
+++ b/docs/content/docs/integrations/better-auth-tanstack.mdx
@@ -26,7 +26,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
       persistClient={false}
       replace={router.replace}
       onSessionChange={() => router.refresh()}
-      Link={Link}
+      LinkComponent={Link}
     >
       {children}
     </AuthUIProviderTanstack>

--- a/docs/content/docs/integrations/next-js.mdx
+++ b/docs/content/docs/integrations/next-js.mdx
@@ -46,7 +46,7 @@ export function Providers({ children }: { children: ReactNode }) {
                 // Clear router cache (protected routes)
                 router.refresh()
             }}
-            Link={Link}
+            LinkComponent={Link}
         >
             {children}
         </AuthUIProvider>
@@ -169,7 +169,7 @@ export default function App({ Component, pageProps }: AppProps) {
             navigate={router.push}
             replace={router.replace}
             onSessionChange={() => router.reload()}
-            Link={Link}
+            LinkComponent={Link}
         >
             <Component {...pageProps} />
         </AuthUIProvider>

--- a/docs/content/docs/integrations/react.mdx
+++ b/docs/content/docs/integrations/react.mdx
@@ -24,7 +24,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
       <AuthUIProvider
         authClient={authClient}
         navigate={navigate}
-        Link={NavLink}
+        LinkComponent={NavLink}
       >
           {children}
       </AuthUIProvider>


### PR DESCRIPTION
Looks like in version 1.2.42 `AuthUIProvider` prop taking the Link component is still `LinkComponent` while docs/website are showing `Link`.  Looks like docs were updated prior to this change being merged in?