### PR TITLE
refactor: const asserted `authViewPaths` for better typing

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,17 +53,8 @@
             }
         }
     },
-    "files": [
-        "src",
-        "dist"
-    ],
-    "keywords": [
-        "typescript",
-        "react",
-        "better-auth",
-        "shadcn",
-        "nextjs"
-    ],
+    "files": ["src", "dist"],
+    "keywords": ["typescript", "react", "better-auth", "shadcn", "nextjs"],
     "author": "daveycodez",
     "license": "MIT",
     "devDependencies": {

--- a/src/components/auth/auth-card.tsx
+++ b/src/components/auth/auth-card.tsx
@@ -8,7 +8,7 @@ import type { AuthLocalization } from "../../lib/auth-localization"
 import { AuthUIContext } from "../../lib/auth-ui-provider"
 import type { AuthView } from "../../lib/auth-view-paths"
 import { socialProviders } from "../../lib/social-providers"
-import { cn, getAuthViewPath } from "../../lib/utils"
+import { cn, getAuthViewByPath } from "../../lib/utils"
 import { SettingsCards, type SettingsCardsClassNames } from "../settings/settings-cards"
 import { Button } from "../ui/button"
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "../ui/card"
@@ -99,7 +99,7 @@ export function AuthCard({
     }
 
     const path = pathname?.split("/").pop()
-    view = view || getAuthViewPath(viewPaths, path) || "signIn"
+    view = view || getAuthViewByPath(viewPaths, path) || "signIn"
 
     const [isSubmitting, setIsSubmitting] = useState(false)
 

--- a/src/components/auth/auth-card.tsx
+++ b/src/components/auth/auth-card.tsx
@@ -8,7 +8,7 @@ import type { AuthLocalization } from "../../lib/auth-localization"
 import { AuthUIContext } from "../../lib/auth-ui-provider"
 import type { AuthView } from "../../lib/auth-view-paths"
 import { socialProviders } from "../../lib/social-providers"
-import { cn, getKeyByValue } from "../../lib/utils"
+import { cn, getAuthViewPath } from "../../lib/utils"
 import { SettingsCards, type SettingsCardsClassNames } from "../settings/settings-cards"
 import { Button } from "../ui/button"
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "../ui/card"
@@ -99,7 +99,7 @@ export function AuthCard({
     }
 
     const path = pathname?.split("/").pop()
-    view = view || getKeyByValue(viewPaths, path) || "signIn"
+    view = view || getAuthViewPath(viewPaths, path) || "signIn"
 
     const [isSubmitting, setIsSubmitting] = useState(false)
 

--- a/src/components/auth/auth-form.tsx
+++ b/src/components/auth/auth-form.tsx
@@ -5,7 +5,7 @@ import { useContext, useEffect } from "react"
 import type { AuthLocalization } from "../../lib/auth-localization"
 import { AuthUIContext } from "../../lib/auth-ui-provider"
 import type { AuthView } from "../../lib/auth-view-paths"
-import { getKeyByValue } from "../../lib/utils"
+import { getAuthViewPath } from "../../lib/utils"
 import { AuthCallback } from "./auth-callback"
 import { ForgotPasswordForm } from "./forms/forgot-password-form"
 import { MagicLinkForm } from "./forms/magic-link-form"
@@ -76,13 +76,13 @@ export function AuthForm({
     const path = pathname?.split("/").pop()
 
     useEffect(() => {
-        if (path && !getKeyByValue(viewPaths, path)) {
+        if (path && !getAuthViewPath(viewPaths, path)) {
             console.error(`Invalid auth view: ${path}`)
             replace(`${basePath}/${viewPaths.signIn}${window.location.search}`)
         }
     }, [path, viewPaths, basePath, replace])
 
-    view = view || getKeyByValue(viewPaths, path) || "signIn"
+    view = view || getAuthViewPath(viewPaths, path) || "signIn"
 
     // Redirect to appropriate view based on enabled features
     useEffect(() => {

--- a/src/components/auth/auth-form.tsx
+++ b/src/components/auth/auth-form.tsx
@@ -5,7 +5,7 @@ import { useContext, useEffect } from "react"
 import type { AuthLocalization } from "../../lib/auth-localization"
 import { AuthUIContext } from "../../lib/auth-ui-provider"
 import type { AuthView } from "../../lib/auth-view-paths"
-import { getAuthViewPath } from "../../lib/utils"
+import { getAuthViewByPath } from "../../lib/utils"
 import { AuthCallback } from "./auth-callback"
 import { ForgotPasswordForm } from "./forms/forgot-password-form"
 import { MagicLinkForm } from "./forms/magic-link-form"
@@ -76,13 +76,13 @@ export function AuthForm({
     const path = pathname?.split("/").pop()
 
     useEffect(() => {
-        if (path && !getAuthViewPath(viewPaths, path)) {
+        if (path && !getAuthViewByPath(viewPaths, path)) {
             console.error(`Invalid auth view: ${path}`)
             replace(`${basePath}/${viewPaths.signIn}${window.location.search}`)
         }
     }, [path, viewPaths, basePath, replace])
 
-    view = view || getAuthViewPath(viewPaths, path) || "signIn"
+    view = view || getAuthViewByPath(viewPaths, path) || "signIn"
 
     // Redirect to appropriate view based on enabled features
     useEffect(() => {

--- a/src/lib/auth-view-paths.ts
+++ b/src/lib/auth-view-paths.ts
@@ -19,7 +19,7 @@ export const authViewPaths = {
     signUp: "sign-up",
     /** @default "two-factor" */
     twoFactor: "two-factor"
-}
+} as const
 
 export type AuthViewPaths = typeof authViewPaths
-export type AuthView = keyof typeof authViewPaths
+export type AuthView = keyof AuthViewPaths

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,7 +1,7 @@
 import { type ClassValue, clsx } from "clsx"
 import { twMerge } from "tailwind-merge"
 import type { AuthLocalization } from "./auth-localization"
-import type { AuthView, AuthViewPaths} from "./auth-view-paths";
+import type { AuthView, AuthViewPaths } from "./auth-view-paths"
 
 export function cn(...inputs: ClassValue[]) {
     return twMerge(clsx(inputs))
@@ -56,16 +56,12 @@ export function getSearchParam(paramName: string) {
         : null
 }
 
-export function getAuthViewByPath(
-    authViewPaths: AuthViewPaths,
-    path?: string | undefined,
-): AuthView | undefined {
+export function getAuthViewByPath(authViewPaths: AuthViewPaths, path?: string) {
     for (const authViewPathsKey in authViewPaths) {
         if (authViewPaths[authViewPathsKey as AuthView] === path) {
             return authViewPathsKey as AuthView
         }
     }
-    return undefined;
 }
 
 export function getKeyByValue<T extends Record<string, unknown>>(

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,7 @@
 import { type ClassValue, clsx } from "clsx"
 import { twMerge } from "tailwind-merge"
 import type { AuthLocalization } from "./auth-localization"
+import type { AuthView, AuthViewPaths} from "./auth-view-paths";
 
 export function cn(...inputs: ClassValue[]) {
     return twMerge(clsx(inputs))
@@ -53,6 +54,19 @@ export function getSearchParam(paramName: string) {
     return typeof window !== "undefined"
         ? new URLSearchParams(window.location.search).get(paramName)
         : null
+}
+
+export function getAuthViewPath(
+    authViewPaths: AuthViewPaths,
+    view?: string | undefined,
+): AuthView | undefined {
+    if (!view) {
+        return undefined
+    }
+
+    if (view in authViewPaths) {
+        return view as AuthView
+    }
 }
 
 export function getKeyByValue<T extends Record<string, unknown>>(

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -56,16 +56,14 @@ export function getSearchParam(paramName: string) {
         : null
 }
 
-export function getAuthViewPath(
+export function getAuthViewByPath(
     authViewPaths: AuthViewPaths,
-    view?: string | undefined,
+    path?: string | undefined,
 ): AuthView | undefined {
-    if (!view) {
-        return undefined
-    }
-
-    if (view in authViewPaths) {
-        return view as AuthView
+    for (const authViewPathsKey in authViewPaths) {
+        if (authViewPaths[authViewPathsKey as AuthView] === path) {
+            return authViewPathsKey as AuthView
+        }
     }
 }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -65,6 +65,7 @@ export function getAuthViewByPath(
             return authViewPathsKey as AuthView
         }
     }
+    return undefined;
 }
 
 export function getKeyByValue<T extends Record<string, unknown>>(

--- a/src/types/auth-client.ts
+++ b/src/types/auth-client.ts
@@ -3,8 +3,8 @@ import type {
     genericOAuthClient,
     magicLinkClient,
     multiSessionClient,
-    passkeyClient,
     oneTapClient,
+    passkeyClient,
     twoFactorClient,
     usernameClient
 } from "better-auth/client/plugins"


### PR DESCRIPTION
- Added `as const` ([const assertion](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#const-assertions)) to `authViewPaths`, which changes type of `authViewPaths` object's keys from `string` to string literals, thus informing **Typescript** of exact possible values.
- Replaced `getKeyByValue` to `getAuthViewPath` for improved clarity. _Original `getKeyByValue` function remains untouched._