### PR TITLE
fix missing invalidEmailOrPassword

### DIFF
--- a/src/lib/auth-localization.ts
+++ b/src/lib/auth-localization.ts
@@ -441,6 +441,9 @@ export const authLocalization = {
 
     /** @default "Invalid password" */
     invalidPassword: "Invalid password",
+    
+    /** @default "Invalid email or password" */
+    invalidEmailOrPassword: "Invalid email or password",
 
     /** @default "Password too short" */
     passwordTooShort: "Password too short",


### PR DESCRIPTION
Closes #79

Generally speaking, I believe it would be better to keep the original spelling/casing of the errors from `BASE_ERROR_CODES` so that the types can be automatically inferred from the `better-auth` package.