### PR TITLE
style: allow user-button menu to align

### DIFF
--- a/src/components/user-button.tsx
+++ b/src/components/user-button.tsx
@@ -63,6 +63,10 @@ export interface UserButtonProps {
      * @default "icon"
      */
     size?: "icon" | "full"
+    /**
+     * @default "end"
+     */
+    align?: "start" | "center" | "end"
 }
 
 type DeviceSession = {
@@ -86,7 +90,8 @@ export function UserButton({
     additionalLinks,
     disableDefaultLinks,
     localization,
-    size = "icon"
+    size = "icon",
+    align = "end"
 }: UserButtonProps) {
     const {
         basePath,
@@ -142,7 +147,7 @@ export function UserButton({
     }, [sessionData, multiSession])
 
     return (
-        <DropdownMenu>
+        <DropdownMenu >
             <DropdownMenuTrigger
                 asChild={size === "full"}
                 className={cn(size === "icon" && "rounded-full", classNames?.trigger?.base)}
@@ -189,6 +194,7 @@ export function UserButton({
             <DropdownMenuContent
                 className={cn("max-w-64", classNames?.content?.base)}
                 onCloseAutoFocus={(e) => e.preventDefault()}
+                align={align}
             >
                 <div className={cn("p-2", classNames?.content?.menuItem)}>
                     {(user && !user.isAnonymous) || isPending ? (


### PR DESCRIPTION
This pull request introduces a new `align` prop to the `UserButton` component in `src/components/user-button.tsx`, allowing developers to control the alignment of the dropdown menu. The default value for this new prop is `"end"`. The most important changes are as follows:

### Addition of the `align` Prop:

* [`src/components/user-button.tsx`](diffhunk://#diff-20bfa8b6b6dd7b4144c83aaeaad65768fb44ec1865f5ff1e381969fb6cefed47R66-R69): Added a new `align` prop to the `UserButtonProps` interface, with possible values `"start"`, `"center"`, and `"end"`, and set its default value to `"end"`. [[1]](diffhunk://#diff-20bfa8b6b6dd7b4144c83aaeaad65768fb44ec1865f5ff1e381969fb6cefed47R66-R69) [[2]](diffhunk://#diff-20bfa8b6b6dd7b4144c83aaeaad65768fb44ec1865f5ff1e381969fb6cefed47L89-R94)

### Implementation of the `align` Prop:

* [`src/components/user-button.tsx`](diffhunk://#diff-20bfa8b6b6dd7b4144c83aaeaad65768fb44ec1865f5ff1e381969fb6cefed47R197): Passed the `align` prop to the `DropdownMenuContent` component to control the alignment of the dropdown menu.