### PR TITLE
style: allow user-button menu to align

### DIFF
--- a/src/components/user-button.tsx
+++ b/src/components/user-button.tsx
@@ -63,6 +63,10 @@ export interface UserButtonProps {
      * @default "icon"
      */
     size?: "icon" | "full"
+    /**
+     * @default "end"
+     */
+    align?: "start" | "center" | "end"
 }
 
 type DeviceSession = {
@@ -86,7 +90,8 @@ export function UserButton({
     additionalLinks,
     disableDefaultLinks,
     localization,
-    size = "icon"
+    size = "icon",
+    align = "end"
 }: UserButtonProps) {
     const {
         basePath,
@@ -142,7 +147,7 @@ export function UserButton({
     }, [sessionData, multiSession])
 
     return (
-        <DropdownMenu>
+        <DropdownMenu >
             <DropdownMenuTrigger
                 asChild={size === "full"}
                 className={cn(size === "icon" && "rounded-full", classNames?.trigger?.base)}
@@ -189,6 +194,7 @@ export function UserButton({
             <DropdownMenuContent
                 className={cn("max-w-64", classNames?.content?.base)}
                 onCloseAutoFocus={(e) => e.preventDefault()}
+                align={align}
             >
                 <div className={cn("p-2", classNames?.content?.menuItem)}>
                     {(user && !user.isAnonymous) || isPending ? (


### PR DESCRIPTION
This pull request enhances the `UserButton` component by introducing a new `align` prop to control the alignment of the dropdown menu. The default alignment is set to `"end"`. The changes ensure that the alignment behavior is customizable and integrated into the component's structure.

### Enhancements to `UserButton` component:

* **New `align` prop added to `UserButtonProps` interface**: The `align` prop allows specifying the alignment of the dropdown menu, with possible values `"start"`, `"center"`, and `"end"`. The default value is `"end"`. (`src/components/user-button.tsx`, [src/components/user-button.tsxR66-R69](diffhunk://#diff-20bfa8b6b6dd7b4144c83aaeaad65768fb44ec1865f5ff1e381969fb6cefed47R66-R69))

* **Default value for `align` prop set in `UserButton` function**: The `align` prop is destructured and initialized with its default value `"end"`. (`src/components/user-button.tsx`, [src/components/user-button.tsxL89-R94](diffhunk://#diff-20bfa8b6b6dd7b4144c83aaeaad65768fb44ec1865f5ff1e381969fb6cefed47L89-R94))

* **`align` prop passed to `DropdownMenuContent`**: The `align` prop is utilized to control the alignment of the dropdown menu content dynamically. (`src/components/user-button.tsx`, [src/components/user-button.tsxR197](diffhunk://#diff-20bfa8b6b6dd7b4144c83aaeaad65768fb44ec1865f5ff1e381969fb6cefed47R197))[Copilot is generating a summary...]