### PR TITLE
fix: Unable to translate locals: remove 'as const' from localization exports

### DIFF
--- a/src/localization/admin-error-codes.ts
+++ b/src/localization/admin-error-codes.ts
@@ -17,4 +17,4 @@ export const ADMIN_ERROR_CODES = {
     YOU_ARE_NOT_ALLOWED_TO_SET_USERS_PASSWORD:
         "You are not allowed to set users password",
     BANNED_USER: "You have been banned from this application"
-} as const
+};

--- a/src/localization/anonymous-error-codes.ts
+++ b/src/localization/anonymous-error-codes.ts
@@ -3,4 +3,4 @@ export const ANONYMOUS_ERROR_CODES = {
     COULD_NOT_CREATE_SESSION: "Could not create session",
     ANONYMOUS_USERS_CANNOT_SIGN_IN_AGAIN_ANONYMOUSLY:
         "Anonymous users cannot sign in again anonymously"
-} as const
+};

--- a/src/localization/base-error-codes.ts
+++ b/src/localization/base-error-codes.ts
@@ -24,4 +24,4 @@ export const BASE_ERROR_CODES = {
     ACCOUNT_NOT_FOUND: "Account not found",
     USER_ALREADY_HAS_PASSWORD:
         "User already has a password. Provide that to delete the account."
-} as const
+};

--- a/src/localization/email-otp-error-codes.ts
+++ b/src/localization/email-otp-error-codes.ts
@@ -4,4 +4,4 @@ export const EMAIL_OTP_ERROR_CODES = {
     INVALID_EMAIL: "Invalid email",
     USER_NOT_FOUND: "User not found",
     TOO_MANY_ATTEMPTS: "Too many attempts"
-} as const
+};

--- a/src/localization/generic-oauth-error-codes.ts
+++ b/src/localization/generic-oauth-error-codes.ts
@@ -1,3 +1,3 @@
 export const GENERIC_OAUTH_ERROR_CODES = {
     INVALID_OAUTH_CONFIGURATION: "Invalid OAuth configuration"
-} as const
+};

--- a/src/localization/haveibeenpwned-error-codes.ts
+++ b/src/localization/haveibeenpwned-error-codes.ts
@@ -1,4 +1,4 @@
 export const HAVEIBEENPWNED_ERROR_CODES = {
     PASSWORD_COMPROMISED:
         "The password you entered has been compromised. Please choose a different password."
-} as const
+};

--- a/src/localization/multi-session-error-codes.ts
+++ b/src/localization/multi-session-error-codes.ts
@@ -1,3 +1,3 @@
 export const MULTI_SESSION_ERROR_CODES = {
     INVALID_SESSION_TOKEN: "Invalid session token"
-} as const
+};

--- a/src/localization/organization-error-codes.ts
+++ b/src/localization/organization-error-codes.ts
@@ -54,4 +54,4 @@ export const ORGANIZATION_ERROR_CODES = {
     YOU_ARE_NOT_ALLOWED_TO_DELETE_THIS_TEAM:
         "You are not allowed to delete this team",
     INVITATION_LIMIT_REACHED: "Invitation limit reached"
-} as const
+};

--- a/src/localization/passkey-error-codes.ts
+++ b/src/localization/passkey-error-codes.ts
@@ -7,4 +7,4 @@ export const PASSKEY_ERROR_CODES = {
     AUTHENTICATION_FAILED: "Authentication failed",
     UNABLE_TO_CREATE_SESSION: "Unable to create session",
     FAILED_TO_UPDATE_PASSKEY: "Failed to update passkey"
-} as const
+};

--- a/src/localization/phone-number-error-codes.ts
+++ b/src/localization/phone-number-error-codes.ts
@@ -7,4 +7,4 @@ export const PHONE_NUMBER_ERROR_CODES = {
     OTP_EXPIRED: "OTP expired",
     INVALID_OTP: "Invalid OTP",
     PHONE_NUMBER_NOT_VERIFIED: "Phone number not verified"
-} as const
+};

--- a/src/localization/stripe-localization.ts
+++ b/src/localization/stripe-localization.ts
@@ -9,4 +9,4 @@ export const STRIPE_ERROR_CODES = {
     SUBSCRIPTION_NOT_ACTIVE: "Subscription is not active",
     SUBSCRIPTION_NOT_SCHEDULED_FOR_CANCELLATION:
         "Subscription is not scheduled for cancellation"
-} as const
+};

--- a/src/localization/two-factor-error-codes.ts
+++ b/src/localization/two-factor-error-codes.ts
@@ -9,4 +9,4 @@ export const TWO_FACTOR_ERROR_CODES = {
     TOO_MANY_ATTEMPTS_REQUEST_NEW_CODE:
         "Too many attempts. Please request a new code.",
     INVALID_TWO_FACTOR_COOKIE: "Invalid two factor cookie"
-} as const
+};


### PR DESCRIPTION
With `as const` in the localization string definitions, it is impossible to overwrite the local strings as the compiler will require exact string matching.