### PR TITLE
Add autoComplete prop for username/email in SignInForm

### DIFF
--- a/src/components/auth/forms/sign-in-form.tsx
+++ b/src/components/auth/forms/sign-in-form.tsx
@@ -182,6 +182,7 @@ export function SignInForm({
 
                             <FormControl>
                                 <Input
+                                    autoComplete={usernameEnabled ? "username" : "email"}
                                     className={classNames?.input}
                                     type={usernameEnabled ? "text" : "email"}
                                     placeholder={


### PR DESCRIPTION
Use autocomplete attribute on sign-in form to comply to the recommendations issued by chromium project: https://www.chromium.org/developers/design-documents/create-amazing-password-forms