### PR TITLE
Update sign-in-form to use post method

### DIFF
--- a/src/components/auth/forms/sign-in-form.tsx
+++ b/src/components/auth/forms/sign-in-form.tsx
@@ -165,6 +165,7 @@ export function SignInForm({
     return (
         <Form {...form}>
             <form
+                method="post"
                 onSubmit={form.handleSubmit(signIn)}
                 noValidate={isHydrated}
                 className={cn("grid w-full gap-6", className, classNames?.base)}


### PR DESCRIPTION
Although this form is expected to be submitted with javascript, there's a small chance that the user tries to submit the form before the client side script is ready (it has happened a couple times for me now in development). As a result, the form submits as it does by default, but since there's no method specified on the form, it uses the GET method, whcih means the email and password are sent with query parameters which is visible. Since no action is specified, this just makes a GET request to the same signin endpoint (/auth/sign-in) but with the email and password query parameters.

This is bad since query parameters are not expected to be used for sending sensitive credentials and are notorious for showing up in logs

This issue affects all the other auth forms as well.