### PR TITLE
feat: add email info in provider cards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ dist
 .DS_Store
 .source
 .vscode
+
+# Webstorm project files
+.idea

--- a/package.json
+++ b/package.json
@@ -153,7 +153,11 @@
         "vaul": "^1.1.2"
     },
     "pnpm": {
-        "overrides": {}
+        "overrides": {},
+        "onlyBuiltDependencies": [
+            "core-js",
+            "esbuild"
+        ]
     },
     "packageManager": "pnpm@10.12.1"
 }

--- a/package.json
+++ b/package.json
@@ -153,11 +153,7 @@
         "vaul": "^1.1.2"
     },
     "pnpm": {
-        "overrides": {},
-        "onlyBuiltDependencies": [
-            "core-js",
-            "esbuild"
-        ]
+        "overrides": {}
     },
     "packageManager": "pnpm@10.12.1"
 }

--- a/src/components/auth/forms/sign-in-form.tsx
+++ b/src/components/auth/forms/sign-in-form.tsx
@@ -182,7 +182,9 @@ export function SignInForm({
 
                             <FormControl>
                                 <Input
-                                    autoComplete={usernameEnabled ? "username" : "email"}
+                                    autoComplete={
+                                        usernameEnabled ? "username" : "email"
+                                    }
                                     className={classNames?.input}
                                     type={usernameEnabled ? "text" : "email"}
                                     placeholder={

--- a/src/components/settings/providers/provider-cell.tsx
+++ b/src/components/settings/providers/provider-cell.tsx
@@ -11,8 +11,8 @@ import type { AuthLocalization } from "../../../localization/auth-localization"
 import type { Refetch } from "../../../types/refetch"
 import { Button } from "../../ui/button"
 import { Card } from "../../ui/card"
+import { Skeleton } from "../../ui/skeleton"
 import type { SettingsCardClassNames } from "../shared/settings-card"
-import { SettingsCellSkeleton } from "../skeletons/settings-cell-skeleton"
 
 export interface ProviderCellProps {
     className?: string
@@ -43,25 +43,13 @@ export function ProviderCell({
         baseURL,
         localization: contextLocalization,
         mutators: { unlinkAccount },
-        hooks: { useAccountInfo },
         viewPaths,
         toast
     } = useContext(AuthUIContext)
 
     localization = { ...contextLocalization, ...localization }
 
-    const { data: accountInfo, isPending } = useAccountInfo(
-        account
-            ? {
-                  accountId: account.accountId
-              }
-            : null
-    )
     const [isLoading, setIsLoading] = useState(false)
-
-    if (isPending) {
-        return <SettingsCellSkeleton classNames={classNames} />
-    }
 
     const handleLink = async () => {
         setIsLoading(true)
@@ -123,11 +111,11 @@ export function ProviderCell({
                 <provider.icon className={cn("size-4", classNames?.icon)} />
             )}
 
-            <span className="text-sm">{provider.name}</span>
+            <div className="flex-col">
+                <div className="text-sm">{provider.name}</div>
 
-            {accountInfo?.user?.email && (
-                <span className="text-sm">{accountInfo.user.email}</span>
-            )}
+                {account && <AccountInfo account={account} />}
+            </div>
 
             <Button
                 className={cn("relative ms-auto", classNames?.button)}
@@ -141,5 +129,27 @@ export function ProviderCell({
                 {account ? localization.UNLINK : localization.LINK}
             </Button>
         </Card>
+    )
+}
+
+function AccountInfo({ account }: { account: { accountId: string } }) {
+    const {
+        hooks: { useAccountInfo }
+    } = useContext(AuthUIContext)
+
+    const { data: accountInfo, isPending } = useAccountInfo({
+        accountId: account.accountId
+    })
+
+    if (isPending) {
+        return <Skeleton className="my-0.5 h-3 w-28" />
+    }
+
+    if (!accountInfo) return null
+
+    return (
+        <div className="text-muted-foreground text-xs">
+            {accountInfo?.user.email}
+        </div>
     )
 }

--- a/src/components/settings/providers/provider-cell.tsx
+++ b/src/components/settings/providers/provider-cell.tsx
@@ -12,11 +12,15 @@ import type { Refetch } from "../../../types/refetch"
 import { Button } from "../../ui/button"
 import { Card } from "../../ui/card"
 import type { SettingsCardClassNames } from "../shared/settings-card"
+import { SettingsCellSkeleton } from "../skeletons/settings-cell-skeleton"
 
 export interface ProviderCellProps {
     className?: string
     classNames?: SettingsCardClassNames
-    account?: { accountId: string; provider: string } | null
+    account?: {
+        accountId: string
+        provider: string
+    } | null
     isPending?: boolean
     localization?: Partial<AuthLocalization>
     other?: boolean
@@ -39,13 +43,25 @@ export function ProviderCell({
         baseURL,
         localization: contextLocalization,
         mutators: { unlinkAccount },
+        hooks: { useAccountInfo },
         viewPaths,
         toast
     } = useContext(AuthUIContext)
 
     localization = { ...contextLocalization, ...localization }
 
+    const { data: accountInfo, isPending } = useAccountInfo(
+        account
+            ? {
+                  accountId: account.accountId
+              }
+            : null
+    )
     const [isLoading, setIsLoading] = useState(false)
+
+    if (isPending) {
+        return <SettingsCellSkeleton classNames={classNames} />
+    }
 
     const handleLink = async () => {
         setIsLoading(true)
@@ -108,6 +124,10 @@ export function ProviderCell({
             )}
 
             <span className="text-sm">{provider.name}</span>
+
+            {accountInfo?.user?.email && (
+                <span className="text-sm">{accountInfo.user.email}</span>
+            )}
 
             <Button
                 className={cn("relative ms-auto", classNames?.button)}

--- a/src/lib/auth-ui-provider.tsx
+++ b/src/lib/auth-ui-provider.tsx
@@ -724,14 +724,8 @@ export const AuthUIProvider = ({
                 }),
             useAccountInfo: (params) =>
                 useAuthData({
-                    queryFn: async () =>
-                        params
-                            ? await authClient.accountInfo(params)
-                            : {
-                                  data: null,
-                                  error: null
-                              },
-                    cacheKey: `accountInfo-${JSON.stringify(params)}`
+                    queryFn: () => authClient.accountInfo(params),
+                    cacheKey: `accountInfo:${JSON.stringify(params)}`
                 }),
             useListDeviceSessions: () =>
                 useAuthData({

--- a/src/lib/auth-ui-provider.tsx
+++ b/src/lib/auth-ui-provider.tsx
@@ -722,6 +722,17 @@ export const AuthUIProvider = ({
                     queryFn: authClient.listAccounts,
                     cacheKey: "listAccounts"
                 }),
+            useAccountInfo: (params) =>
+                useAuthData({
+                    queryFn: async () =>
+                        params
+                            ? await authClient.accountInfo(params)
+                            : {
+                                  data: null,
+                                  error: null
+                              },
+                    cacheKey: `accountInfo-${JSON.stringify(params)}`
+                }),
             useListDeviceSessions: () =>
                 useAuthData({
                     queryFn: authClient.multiSession.listDeviceSessions,

--- a/src/localization/admin-error-codes.ts
+++ b/src/localization/admin-error-codes.ts
@@ -17,4 +17,4 @@ export const ADMIN_ERROR_CODES = {
     YOU_ARE_NOT_ALLOWED_TO_SET_USERS_PASSWORD:
         "You are not allowed to set users password",
     BANNED_USER: "You have been banned from this application"
-};
+}

--- a/src/localization/anonymous-error-codes.ts
+++ b/src/localization/anonymous-error-codes.ts
@@ -3,4 +3,4 @@ export const ANONYMOUS_ERROR_CODES = {
     COULD_NOT_CREATE_SESSION: "Could not create session",
     ANONYMOUS_USERS_CANNOT_SIGN_IN_AGAIN_ANONYMOUSLY:
         "Anonymous users cannot sign in again anonymously"
-};
+}

--- a/src/localization/base-error-codes.ts
+++ b/src/localization/base-error-codes.ts
@@ -24,4 +24,4 @@ export const BASE_ERROR_CODES = {
     ACCOUNT_NOT_FOUND: "Account not found",
     USER_ALREADY_HAS_PASSWORD:
         "User already has a password. Provide that to delete the account."
-};
+}

--- a/src/localization/email-otp-error-codes.ts
+++ b/src/localization/email-otp-error-codes.ts
@@ -4,4 +4,4 @@ export const EMAIL_OTP_ERROR_CODES = {
     INVALID_EMAIL: "Invalid email",
     USER_NOT_FOUND: "User not found",
     TOO_MANY_ATTEMPTS: "Too many attempts"
-};
+}

--- a/src/localization/generic-oauth-error-codes.ts
+++ b/src/localization/generic-oauth-error-codes.ts
@@ -1,3 +1,3 @@
 export const GENERIC_OAUTH_ERROR_CODES = {
     INVALID_OAUTH_CONFIGURATION: "Invalid OAuth configuration"
-};
+}

--- a/src/localization/haveibeenpwned-error-codes.ts
+++ b/src/localization/haveibeenpwned-error-codes.ts
@@ -1,4 +1,4 @@
 export const HAVEIBEENPWNED_ERROR_CODES = {
     PASSWORD_COMPROMISED:
         "The password you entered has been compromised. Please choose a different password."
-};
+}

--- a/src/localization/multi-session-error-codes.ts
+++ b/src/localization/multi-session-error-codes.ts
@@ -1,3 +1,3 @@
 export const MULTI_SESSION_ERROR_CODES = {
     INVALID_SESSION_TOKEN: "Invalid session token"
-};
+}

--- a/src/localization/organization-error-codes.ts
+++ b/src/localization/organization-error-codes.ts
@@ -54,4 +54,4 @@ export const ORGANIZATION_ERROR_CODES = {
     YOU_ARE_NOT_ALLOWED_TO_DELETE_THIS_TEAM:
         "You are not allowed to delete this team",
     INVITATION_LIMIT_REACHED: "Invitation limit reached"
-};
+}

--- a/src/localization/passkey-error-codes.ts
+++ b/src/localization/passkey-error-codes.ts
@@ -7,4 +7,4 @@ export const PASSKEY_ERROR_CODES = {
     AUTHENTICATION_FAILED: "Authentication failed",
     UNABLE_TO_CREATE_SESSION: "Unable to create session",
     FAILED_TO_UPDATE_PASSKEY: "Failed to update passkey"
-};
+}

--- a/src/localization/phone-number-error-codes.ts
+++ b/src/localization/phone-number-error-codes.ts
@@ -7,4 +7,4 @@ export const PHONE_NUMBER_ERROR_CODES = {
     OTP_EXPIRED: "OTP expired",
     INVALID_OTP: "Invalid OTP",
     PHONE_NUMBER_NOT_VERIFIED: "Phone number not verified"
-};
+}

--- a/src/localization/stripe-localization.ts
+++ b/src/localization/stripe-localization.ts
@@ -9,4 +9,4 @@ export const STRIPE_ERROR_CODES = {
     SUBSCRIPTION_NOT_ACTIVE: "Subscription is not active",
     SUBSCRIPTION_NOT_SCHEDULED_FOR_CANCELLATION:
         "Subscription is not scheduled for cancellation"
-};
+}

--- a/src/localization/two-factor-error-codes.ts
+++ b/src/localization/two-factor-error-codes.ts
@@ -9,4 +9,4 @@ export const TWO_FACTOR_ERROR_CODES = {
     TOO_MANY_ATTEMPTS_REQUEST_NEW_CODE:
         "Too many attempts. Please request a new code.",
     INVALID_TWO_FACTOR_COOKIE: "Invalid two factor cookie"
-};
+}

--- a/src/types/auth-hooks.ts
+++ b/src/types/auth-hooks.ts
@@ -1,4 +1,5 @@
 import type { BetterFetchError } from "@better-fetch/fetch"
+import type { User } from "better-auth"
 import type { Invitation } from "better-auth/plugins/organization"
 import type { AnyAuthClient } from "./any-auth-client"
 import type { ApiKey } from "./api-key"
@@ -18,8 +19,8 @@ export type AuthHooks = {
     useSession: () => ReturnType<AnyAuthClient["useSession"]>
     useListAccounts: () => AuthHook<{ accountId: string; provider: string }[]>
     useAccountInfo: (
-        params: Parameters<AuthClient["accountInfo"]>[0] | null
-    ) => AuthHook<ReturnType<AuthClient["accountInfo"]>>
+        params: Parameters<AuthClient["accountInfo"]>[0]
+    ) => AuthHook<{ user: User }>
     useListDeviceSessions: () => AuthHook<AnyAuthClient["$Infer"]["Session"][]>
     useListSessions: () => AuthHook<AnyAuthSession["session"][]>
     useListPasskeys: () => Partial<ReturnType<AuthClient["useListPasskeys"]>>

--- a/src/types/auth-hooks.ts
+++ b/src/types/auth-hooks.ts
@@ -19,16 +19,7 @@ export type AuthHooks = {
     useListAccounts: () => AuthHook<{ accountId: string; provider: string }[]>
     useAccountInfo: (
         params: Parameters<AuthClient["accountInfo"]>[0] | null
-    ) => AuthHook<{
-        user: {
-            id: string
-            name?: string
-            email?: string | null
-            image?: string
-            emailVerified: boolean
-        }
-        data: Record<string, any>
-    }>
+    ) => AuthHook<ReturnType<AuthClient["accountInfo"]>>
     useListDeviceSessions: () => AuthHook<AnyAuthClient["$Infer"]["Session"][]>
     useListSessions: () => AuthHook<AnyAuthSession["session"][]>
     useListPasskeys: () => Partial<ReturnType<AuthClient["useListPasskeys"]>>

--- a/src/types/auth-hooks.ts
+++ b/src/types/auth-hooks.ts
@@ -17,6 +17,18 @@ type AuthHook<T> = {
 export type AuthHooks = {
     useSession: () => ReturnType<AnyAuthClient["useSession"]>
     useListAccounts: () => AuthHook<{ accountId: string; provider: string }[]>
+    useAccountInfo: (
+        params: Parameters<AuthClient["accountInfo"]>[0] | null
+    ) => AuthHook<{
+        user: {
+            id: string
+            name?: string
+            email?: string | null
+            image?: string
+            emailVerified: boolean
+        }
+        data: Record<string, any>
+    }>
     useListDeviceSessions: () => AuthHook<AnyAuthClient["$Infer"]["Session"][]>
     useListSessions: () => AuthHook<AnyAuthSession["session"][]>
     useListPasskeys: () => Partial<ReturnType<AuthClient["useListPasskeys"]>>


### PR DESCRIPTION
This PR adds support for displaying emails inside the auth provider cards if available. Related feature request: https://betterauthui.featurebase.app/en/p/feature-request-display-the-linked-email-below-the-provider