### PR TITLE
Chore: Fix missing backticks

### DIFF
--- a/docs/content/docs/advanced/custom-settings.mdx
+++ b/docs/content/docs/advanced/custom-settings.mdx
@@ -70,7 +70,7 @@ settings={{
     basePath: "/dashboard",
     fields: ["image", "name", "age"] // Specify which fields to show
 }}
-
+```
 ### Using SettingsCards with pathname
 
 When using `settings.basePath`, you can pass the `pathname` prop to `<SettingsCards />` to automatically determine the current view:


### PR DESCRIPTION
<img width="823" height="624" alt="image" src="https://github.com/user-attachments/assets/8c0f85e2-9f82-469c-a177-64ef812cc61c" />
due to missing backticks this is how https://better-auth-ui.com/advanced/custom-settings is looking