### PR TITLE
fix: exposes alignOffset, side + sideOffset

### DIFF
--- a/src/components/organization/organization-switcher.tsx
+++ b/src/components/organization/organization-switcher.tsx
@@ -64,6 +64,9 @@ export interface OrganizationSwitcherProps
     extends Omit<ComponentProps<typeof Button>, "trigger"> {
     classNames?: OrganizationSwitcherClassNames
     align?: "center" | "start" | "end"
+    alignOffset?: number
+    side?: "top" | "right" | "bottom" | "left"
+    sideOffset?: number
     trigger?: ReactNode
     localization?: AuthLocalization
     slug?: string
@@ -91,6 +94,9 @@ export function OrganizationSwitcher({
     className,
     classNames,
     align,
+    alignOffset,
+    side,
+    sideOffset,
     trigger,
     localization: localizationProp,
     slug: slugProp,
@@ -326,6 +332,9 @@ export function OrganizationSwitcher({
                         classNames?.content?.base
                     )}
                     align={align}
+                    alignOffset={alignOffset}
+                    side={side}
+                    sideOffset={sideOffset}
                     onCloseAutoFocus={(e) => e.preventDefault()}
                 >
                     <div

--- a/src/components/user-button.tsx
+++ b/src/components/user-button.tsx
@@ -58,6 +58,9 @@ export interface UserButtonProps {
     className?: string
     classNames?: UserButtonClassNames
     align?: "center" | "start" | "end"
+    alignOffset?: number
+    side?: "top" | "right" | "bottom" | "left"
+    sideOffset?: number
     additionalLinks?: {
         href: string
         icon?: ReactNode
@@ -88,6 +91,9 @@ export function UserButton({
     className,
     classNames,
     align,
+    alignOffset,
+    side,
+    sideOffset,
     trigger,
     additionalLinks,
     disableDefaultLinks,
@@ -228,6 +234,9 @@ export function UserButton({
                     classNames?.content?.base
                 )}
                 align={align}
+                alignOffset={alignOffset}
+                side={side}
+                sideOffset={sideOffset}
                 onCloseAutoFocus={(e) => e.preventDefault()}
             >
                 <div className={cn("p-2", classNames?.content?.menuItem)}>


### PR DESCRIPTION
This update exposes the `alignOffset`, `side` and `sideOffset` allowing users to right align the UserButton dropdown as per Shadcn Sidebar blocks

<img width="671" height="497" alt="image" src="https://github.com/user-attachments/assets/97b1059f-a8d9-4097-b7fd-2a69ac3c8efa" />
