### PR TITLE
Refresh organization after selecting new one

### DIFF
--- a/src/components/organization/organization-switcher.tsx
+++ b/src/components/organization/organization-switcher.tsx
@@ -146,7 +146,8 @@ export function OrganizationSwitcher({
     const {
         data: activeOrganization,
         isPending: organizationPending,
-        isRefetching: organizationRefetching
+        isRefetching: organizationRefetching,
+        refetch: organizationRefetch
     } = useCurrentOrganization({ slug })
 
     const isPending =
@@ -192,6 +193,9 @@ export function OrganizationSwitcher({
                         throw: true
                     }
                 })
+
+                organizationRefetch?.();
+
             } catch (error) {
                 toast({
                     variant: "error",


### PR DESCRIPTION
Hello!

I’ve been testing` <OrganizationSwitcher />` and noticed that switching organizations leaves the component stuck in a loading state.

After some debugging, it looks like this [useEffect](https://github.com/daveyplate/better-auth-ui/blob/main/src/components/organization/organization-switcher.tsx#L159)
 is never triggered.

Here’s the state right after switching:
<img width="185" height="63" alt="image" src="https://github.com/user-attachments/assets/f50085a0-3392-4abf-ae45-f350dd5e6794" />

I added a refresh call, and the switch now works as expected.

Open to any feedback or suggestions.

It may be related to following issue: https://github.com/better-auth/better-auth/issues/3837