### PR TITLE
fix: min-w / max-w for user-button and organization-switcher

### DIFF
--- a/src/components/organization/organization-switcher.tsx
+++ b/src/components/organization/organization-switcher.tsx
@@ -332,7 +332,7 @@ export function OrganizationSwitcher({
 
                 <DropdownMenuContent
                     className={cn(
-                        "w-[--radix-dropdown-menu-trigger-width] min-w-56 max-w-64",
+                        "w-[--radix-dropdown-menu-trigger-width] min-w-56",
                         classNames?.content?.base
                     )}
                     align={align}

--- a/src/components/user-button.tsx
+++ b/src/components/user-button.tsx
@@ -230,7 +230,7 @@ export function UserButton({
 
             <DropdownMenuContent
                 className={cn(
-                    "w-[--radix-dropdown-menu-trigger-width] min-w-56 max-w-64",
+                    "w-[--radix-dropdown-menu-trigger-width] min-w-56",
                     classNames?.content?.base
                 )}
                 align={align}


### PR DESCRIPTION
Hi,
That's a small fix for the conflicting min-w and max-w
the fix aligns with the default shadcn nav-use and team-switcher components:
https://v0.app/chat/open-in-v0-c3EYvXu4nEz

Thanks