### PR TITLE
fix: CSS variable syntax as an arbitrary value shorthand

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
         "react-hook-form": ">=7.55.0",
         "sonner": ">=1.7.0",
         "tailwind-merge": ">=2.6.0",
-        "tailwindcss": ">=3.0.0",
+        "tailwindcss": ">=4.0.0",
         "zod": ">=3.0.0"
     },
     "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 1.1.18
       '@daveyplate/better-auth-tanstack':
         specifier: ^1.3.6
-        version: 1.3.6(@tanstack/query-core@5.85.3)(@tanstack/react-query@5.85.3(react@19.1.0))(better-auth@1.3.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(zod@3.25.76))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.3.6(@tanstack/query-core@5.85.3)(@tanstack/react-query@5.85.3(react@19.1.0))(better-auth@1.3.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(zod@4.0.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@hcaptcha/react-hcaptcha':
         specifier: ^1.12.1
         version: 1.12.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -72,7 +72,7 @@ importers:
         specifier: '>=1.7.0'
         version: 2.0.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       tailwindcss:
-        specifier: '>=3.0.0'
+        specifier: '>=4.0.0'
         version: 4.1.7
       ua-parser-js:
         specifier: ^2.0.4
@@ -152,7 +152,7 @@ importers:
         version: 3.3.1
       tailwindcss-animate:
         specifier: ^1.0.7
-        version: 1.0.7
+        version: 1.0.7(tailwindcss@4.1.7)
       tsc-watch:
         specifier: ^7.1.1
         version: 7.1.1(typescript@5.9.2)
@@ -2214,9 +2214,6 @@ packages:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
 
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
-
   zod@4.0.17:
     resolution: {integrity: sha512-1PHjlYRevNxxdy2JZ8JcNAw7rX8V9P1AKkP+x/xZfxB0K5FYfuV+Ug6P/6NVSR2jHQ+FzDDoDHS04nYUsOIyLQ==}
 
@@ -2265,11 +2262,11 @@ snapshots:
   '@biomejs/cli-win32-x64@2.2.0':
     optional: true
 
-  '@daveyplate/better-auth-tanstack@1.3.6(@tanstack/query-core@5.85.3)(@tanstack/react-query@5.85.3(react@19.1.0))(better-auth@1.3.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(zod@3.25.76))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@daveyplate/better-auth-tanstack@1.3.6(@tanstack/query-core@5.85.3)(@tanstack/react-query@5.85.3(react@19.1.0))(better-auth@1.3.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(zod@4.0.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@tanstack/query-core': 5.85.3
       '@tanstack/react-query': 5.85.3(react@19.1.0)
-      better-auth: 1.3.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(zod@3.25.76)
+      better-auth: 1.3.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(zod@4.0.17)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
@@ -3239,24 +3236,6 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  better-auth@1.3.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(zod@3.25.76):
-    dependencies:
-      '@better-auth/utils': 0.2.6
-      '@better-fetch/fetch': 1.1.18
-      '@noble/ciphers': 0.6.0
-      '@noble/hashes': 1.8.0
-      '@simplewebauthn/browser': 13.1.2
-      '@simplewebauthn/server': 13.1.2
-      better-call: 1.0.13
-      defu: 6.1.4
-      jose: 5.10.0
-      kysely: 0.28.5
-      nanostores: 0.11.4
-      zod: 3.25.76
-    optionalDependencies:
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
   better-auth@1.3.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(zod@4.0.17):
     dependencies:
       '@better-auth/utils': 0.2.6
@@ -3915,7 +3894,9 @@ snapshots:
 
   tailwind-merge@3.3.1: {}
 
-  tailwindcss-animate@1.0.7: {}
+  tailwindcss-animate@1.0.7(tailwindcss@4.1.7):
+    dependencies:
+      tailwindcss: 4.1.7
 
   tailwindcss@4.1.7: {}
 
@@ -4104,7 +4085,5 @@ snapshots:
       ansi-styles: 6.2.1
       string-width: 5.1.2
       strip-ansi: 7.1.0
-
-  zod@3.25.76: {}
 
   zod@4.0.17: {}

--- a/src/components/organization/organization-switcher.tsx
+++ b/src/components/organization/organization-switcher.tsx
@@ -332,7 +332,7 @@ export function OrganizationSwitcher({
 
                 <DropdownMenuContent
                     className={cn(
-                        "w-[--radix-dropdown-menu-trigger-width] min-w-56 max-w-64",
+                        "w-(--radix-dropdown-menu-trigger-width) min-w-56 max-w-64",
                         classNames?.content?.base
                     )}
                     align={align}

--- a/src/components/settings/api-key/create-api-key-dialog.tsx
+++ b/src/components/settings/api-key/create-api-key-dialog.tsx
@@ -209,7 +209,7 @@ export function CreateApiKeyDialog({
                                                 </SelectTrigger>
                                             </FormControl>
 
-                                            <SelectContent className="w-[--radix-select-trigger-width]">
+                                            <SelectContent className="w-(--radix-select-trigger-width)">
                                                 <SelectItem
                                                     value="personal"
                                                     className="p-2"

--- a/src/components/user-button.tsx
+++ b/src/components/user-button.tsx
@@ -230,7 +230,7 @@ export function UserButton({
 
             <DropdownMenuContent
                 className={cn(
-                    "w-[--radix-dropdown-menu-trigger-width] min-w-56 max-w-64",
+                    "w-(--radix-dropdown-menu-trigger-width) min-w-56 max-w-64",
                     classNames?.content?.base
                 )}
                 align={align}


### PR DESCRIPTION
Hi,
This is a fix for the CSS variable syntax as an arbitrary value as mentioned in the tailwind (docs)[https://tailwindcss.com/docs/adding-custom-styles#using-arbitrary-values]
I bumped tailwind version to >=4 as the shorthand syntax was introduced in (v4.0.0-alpha.35)[https://github.com/tailwindlabs/tailwindcss/releases/tag/v4.0.0-alpha.35]

The shorthand syntax is already used in shadcn components:
- https://github.com/daveyplate/better-auth-ui/blob/main/src/components/ui/dropdown-menu.tsx#L45
- https://github.com/daveyplate/better-auth-ui/blob/main/src/components/ui/select.tsx#L64

Please let me know if there is anything needing adjustments
Thanks