### PR TITLE
Fix URL encoding for redirectTo parameters

### DIFF
--- a/src/components/auth/forms/magic-link-form.tsx
+++ b/src/components/auth/forms/magic-link-form.tsx
@@ -73,7 +73,7 @@ export function MagicLinkForm({
             `${baseURL}${
                 callbackURLProp ||
                 (persistClient
-                    ? `${basePath}/${viewPaths.CALLBACK}?redirectTo=${getRedirectTo()}`
+                    ? `${basePath}/${viewPaths.CALLBACK}?redirectTo=${encodeURIComponent(getRedirectTo())}`
                     : getRedirectTo())
             }`,
         [

--- a/src/components/auth/forms/sign-up-form.tsx
+++ b/src/components/auth/forms/sign-up-form.tsx
@@ -109,7 +109,7 @@ export function SignUpForm({
             `${baseURL}${
                 callbackURL ||
                 (persistClient
-                    ? `${basePath}/${viewPaths.CALLBACK}?redirectTo=${getRedirectTo()}`
+                    ? `${basePath}/${viewPaths.CALLBACK}?redirectTo=${encodeURIComponent(getRedirectTo())}`
                     : getRedirectTo())
             }`,
         [

--- a/src/components/auth/provider-button.tsx
+++ b/src/components/auth/provider-button.tsx
@@ -56,7 +56,7 @@ export function ProviderButton({
             `${baseURL}${
                 callbackURLProp ||
                 (persistClient
-                    ? `${basePath}/${viewPaths.CALLBACK}?redirectTo=${getRedirectTo()}`
+                    ? `${basePath}/${viewPaths.CALLBACK}?redirectTo=${encodeURIComponent(getRedirectTo())}`
                     : getRedirectTo())
             }`,
         [

--- a/src/components/settings/providers/provider-cell.tsx
+++ b/src/components/settings/providers/provider-cell.tsx
@@ -50,7 +50,7 @@ export function ProviderCell({
 
     const handleLink = async () => {
         setIsLoading(true)
-        const callbackURL = `${baseURL}${basePath}/${viewPaths.CALLBACK}?redirectTo=${window.location.pathname}`
+        const callbackURL = `${baseURL}${basePath}/${viewPaths.CALLBACK}?redirectTo=${encodeURIComponent(window.location.pathname)}`
 
         try {
             if (other) {

--- a/src/hooks/use-authenticate.ts
+++ b/src/hooks/use-authenticate.ts
@@ -41,7 +41,9 @@ export function useAuthenticate<TAuthClient extends AnyAuthClient>(
             currentUrl.searchParams.get("redirectTo") ||
             window.location.href.replace(window.location.origin, "")
 
-        replace(`${basePath}/${viewPaths[authView]}?redirectTo=${redirectTo}`)
+        replace(
+            `${basePath}/${viewPaths[authView]}?redirectTo=${encodeURIComponent(redirectTo)}`
+        )
     }, [
         isPending,
         sessionData,


### PR DESCRIPTION
Fixes [#223](https://github.com/daveyplate/better-auth-ui/issues/223)

### Problem
All `redirectTo` parameters in URL query strings were not being properly encoded, causing issues when redirect URLs contained special characters like spaces, query parameters, ampersands, or other URL-unsafe characters.

This was particularly problematic for authentication flows with query parameters like:
- Organization invitation acceptance (`?token=...&invitationId=...`)
- Password reset flows
- Email verification flows
- Any custom authentication flows with query parameters

### Solution
Added `encodeURIComponent()` to all URL query string construction where `redirectTo` parameters are used, ensuring proper URL encoding.

### Changes Made
- **Provider Button**: Fixed callback URL construction in `src/components/auth/provider-button.tsx`
- **Sign-up Form**: Fixed callback URL construction in `src/components/auth/forms/sign-up-form.tsx`
- **Magic Link Form**: Fixed callback URL construction in `src/components/auth/forms/magic-link-form.tsx`
- **Provider Cell**: Fixed callback URL construction in `src/components/settings/providers/provider-cell.tsx`
- **useAuthenticate Hook**: Fixed redirectTo parameter in `src/hooks/use-authenticate.ts`

### Before/After Examples
```javascript
// Before (broken)
`?redirectTo=${redirectTo}`

// After (fixed)
`?redirectTo=${encodeURIComponent(redirectTo)}`
```

### Impact
- ✅ Redirect URLs with spaces now work: `/dashboard with spaces` → `%2Fdashboard%20with%20spaces`
- ✅ Redirect URLs with query parameters now work: `/dashboard?tab=settings` → `%2Fdashboard%3Ftab%3Dsettings`
- ✅ Redirect URLs with special characters now work: `/dashboard?query=hello&world=test` → `%2Fdashboard%3Fquery%3Dhello%26world%3Dtest`
- ✅ Organization invitation flows now work correctly
- ✅ Password reset and email verification flows preserve query parameters

### Testing
- ✅ Build passes (`pnpm build`)
- ✅ Linting passes (`pnpm biome check --fix`)
- ✅ URL encoding/decoding verified with test cases
- ✅ No breaking changes to function parameters (only URL query strings)

### Notes
Function parameters (like `redirectTo` in `requestPasswordReset()`) were correctly left unencoded as they are passed directly to auth client methods, not constructed as URLs.