### PR TITLE
fix custom avatar Image bug

### DIFF
--- a/src/lib/auth-ui-provider.tsx
+++ b/src/lib/auth-ui-provider.tsx
@@ -349,7 +349,8 @@ export const AuthUIProvider = ({
             upload: avatarProp.upload,
             delete: avatarProp.delete,
             extension: avatarProp.extension || "png",
-            size: avatarProp.size || (avatarProp.upload ? 256 : 128)
+            size: avatarProp.size || (avatarProp.upload ? 256 : 128),
+            Image: avatarProp.Image
         }
     }, [avatarProp])
 


### PR DESCRIPTION
Passing a custom avatar.Image via AuthUIProvider is ignored. UserAvatar falls back to AvatarImage/AvatarFallback because AuthUIProvider does not include Image in the avatar object it provides through context. I fixed it.