### PR TITLE
fix: add autocomplete attributes to sign-up form inputs

### DIFF
--- a/src/components/auth/forms/sign-up-form.tsx
+++ b/src/components/auth/forms/sign-up-form.tsx
@@ -511,6 +511,7 @@ export function SignUpForm({
 
                                 <FormControl>
                                     <Input
+                                        autoComplete="name"
                                         className={classNames?.input}
                                         placeholder={
                                             localization.NAME_PLACEHOLDER
@@ -539,6 +540,7 @@ export function SignUpForm({
 
                                 <FormControl>
                                     <Input
+                                        autoComplete="username"
                                         className={classNames?.input}
                                         placeholder={
                                             localization.USERNAME_PLACEHOLDER
@@ -566,6 +568,7 @@ export function SignUpForm({
 
                             <FormControl>
                                 <Input
+                                    autoComplete="email"
                                     className={classNames?.input}
                                     type="email"
                                     placeholder={localization.EMAIL_PLACEHOLDER}
@@ -695,6 +698,8 @@ export function SignUpForm({
                                             {additionalField.type ===
                                             "number" ? (
                                                 <Input
+
+                                                    autoComplete={field}
                                                     className={
                                                         classNames?.input
                                                     }
@@ -732,6 +737,8 @@ export function SignUpForm({
                                                 />
                                             ) : (
                                                 <Input
+
+                                                    autoComplete={field}
                                                     className={
                                                         classNames?.input
                                                     }


### PR DESCRIPTION
The sign-up form is missing autoComplete attributes on several input fields, which causes browser warnings about missing autocomplete attributes.

This PR adds:

- autoComplete="name" - name input field
- autoComplete="username" - username input field
- autoComplete="email" - email input field
- autoComplete={field} - additional field number input
- autoComplete={field} - additional field text input

Note: Password inputs already have autoComplete="new-password" set correctly.

The sign-in form already has proper autocomplete attributes, so this PR brings the sign-up form to the same standard.

This addresses browser accessibility warnings and improves form usability with password managers and autofill features.