### PR TITLE
Fix documentation for account path stuff

### DIFF
--- a/docs/content/docs/advanced/custom-auth-paths.mdx
+++ b/docs/content/docs/advanced/custom-auth-paths.mdx
@@ -7,7 +7,7 @@ Here's a complete guide on how to customize view paths using the `AuthUIProvider
 
 ### Step 1: Customize Auth View Paths
 
-First, customize the default built-in paths by providing your custom routes through the `viewPaths` prop on the `<AuthUIProvider />` component.
+First, customize the default built-in auth paths by providing your custom routes through the `viewPaths` prop on the `<AuthUIProvider />` component. The `viewPaths` prop controls authentication pages like sign-in, sign-up, forgot password, etc.
 
 ```tsx
 "use client"
@@ -33,8 +33,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
                 SIGN_UP: "register",
                 FORGOT_PASSWORD: "forgot",
                 RESET_PASSWORD: "reset",
-                MAGIC_LINK: "magic",
-                SETTINGS: "config"
+                MAGIC_LINK: "magic"
             }}
         >
             {children}
@@ -53,7 +52,28 @@ Now your newly configured `viewPaths` object is as follows:
 | `/auth/forgot-password` | `/auth/forgot`    |
 | `/auth/reset-password`  | `/auth/reset`     |
 | `/auth/magic-link`     | `/auth/magic`     |
-| `/auth/settings`     | `/auth/config`     |
+
+### Customizing Account View Paths
+
+Account settings paths (like settings, security, api-keys) are configured separately using the `account.viewPaths` prop:
+
+```tsx
+<AuthUIProvider
+    authClient={authClient}
+    account={{
+        viewPaths: {
+            SETTINGS: "profile",
+            SECURITY: "password",
+            API_KEYS: "keys",
+            ORGANIZATIONS: "orgs"
+        }
+    }}
+>
+    {children}
+</AuthUIProvider>
+```
+
+This would change the paths from `/account/settings` to `/account/profile`, etc.
 
 ## Adjusting Dynamic Auth Route
 
@@ -62,8 +82,8 @@ Next, your authentication page route can dynamically handle these paths. Set up 
 Using Next.js App Router (`app` router):
 
 ```tsx
-import { AuthCard } from "@daveyplate/better-auth-ui"
-import { authViewPaths } from "@daveyplate/better-auth-ui/server"
+import { AuthView } from "@daveyplate/better-auth-ui"
+import { authViewPaths } from "@daveyplate/better-auth-ui"
 
 export function generateStaticParams() {
     return Object.values({
@@ -73,8 +93,7 @@ export function generateStaticParams() {
         SIGN_UP: "register",
         FORGOT_PASSWORD: "forgot",
         RESET_PASSWORD: "reset",
-        MAGIC_LINK: "magic",
-        SETTINGS: "config"
+        MAGIC_LINK: "magic"
     }).map((pathname) => ({ pathname }))
 }
 
@@ -83,11 +102,13 @@ export default async function AuthPage({ params }: { params: Promise<{ pathname:
 
     return (
         <div className="flex flex-col grow size-full items-center justify-center gap-3">
-            <AuthCard pathname={pathname} />
+            <AuthView pathname={pathname} />
         </div>
     )
 }
 ```
+
+> **Note**: The `authViewPaths` object only includes authentication pages, not account settings pages. Account pages are handled separately via the `account` prop configuration.
 
 ### Example usage across your app:
 
@@ -102,7 +123,6 @@ export default function Navbar() {
             <Link href="/auth/login">Login</Link>
             <Link href="/auth/register">Register</Link>
             <Link href="/auth/forgot">Forgot Password</Link>
-            <Link href="/auth/config">Config</Link>
         </nav>
     )
 }
@@ -110,8 +130,9 @@ export default function Navbar() {
 
 ### Summary of Steps (Recap):
 
-- Defined custom view paths within `AuthUIProvider`.
-- Updated dynamic auth page to handle correct paths within `generateStaticParams`.
-- Revised links/apps accordingly to use your newly specified paths.
+- Defined custom auth view paths within `AuthUIProvider` using the `viewPaths` prop
+- Optionally defined custom account view paths using `account.viewPaths`
+- Updated dynamic auth page to handle correct paths within `generateStaticParams`
+- Revised links throughout your app to use the newly specified paths
 
-You have now successfully customized all your authentication URLs using the shipped customization options while preserving all the other features and integrations seamlessly.
+You have now successfully customized your authentication and account URLs using the available customization options while preserving all the other features and integrations seamlessly.

--- a/docs/content/docs/advanced/custom-settings.mdx
+++ b/docs/content/docs/advanced/custom-settings.mdx
@@ -1,34 +1,34 @@
 ---
-title: Custom Settings
+title: Custom Account Settings
 icon: Cog
 ---
 
-The default authentication components provided by `@daveyplate/better-auth-ui` include built-in settings pages accessible under the same base path as your auth views (e.g., `/auth/settings`, `/auth/security`, etc.).
+The `@daveyplate/better-auth-ui` library provides built-in account settings views accessible through the `account` configuration. By default, these views are located at `/account/settings`, `/account/security`, `/account/api-keys`, and `/account/organizations`.
 
 However, for advanced use cases, you may want to:
-1. Move the built-in settings views to a different base path (using `settings.basePath`)
-2. Replace the settings with a completely custom implementation (using `settings.url`)
-3. Build your own settings page using individual components
+1. Move the built-in account views to a different base path (using `account.basePath`)
+2. Build your own account page layout using `<AccountView />` component
+3. Build completely custom settings using individual components
 
 ## Overview
 
-You have three primary ways to customize the settings experience:
+You have three primary ways to customize the account settings experience:
 
-1. **Move settings to a different path**: Use `settings.basePath` to relocate all built-in settings views while keeping their functionality
-2. **Replace with custom settings**: Use `settings.url` to redirect to your completely custom settings implementation
-3. **Build custom layouts**: Import individual settings components to create your own layouts
+1. **Move account views to a different path**: Use `account.basePath` to relocate all built-in account views while keeping their functionality
+2. **Use AccountView component**: Use `<AccountView />` to render the full account management UI with navigation
+3. **Build custom layouts**: Import individual settings components (`AccountSettingsCards`, `SecuritySettingsCards`, etc.) to create your own layouts
 
 ### Quick Comparison
 
 | Option | Use Case | Configuration | Result |
 |--------|----------|---------------|---------|
-| `settings.basePath` | Keep built-in settings but move to different path | `settings: { basePath: "/dashboard" }` | Settings at `/dashboard/settings`, `/dashboard/security`, etc. |
-| `settings.url` | Replace with completely custom settings | `settings: { url: "/my-settings" }` | All settings routes redirect to `/my-settings` |
+| `account.basePath` | Keep built-in account views but move to different path | `account: { basePath: "/dashboard" }` | Account views at `/dashboard/settings`, `/dashboard/security`, etc. |
+| `<AccountView />` | Use the full account UI with navigation | Import and use component | Renders complete account management with sidebar navigation |
 | Individual components | Build custom layouts with specific components | Import components directly | Full control over layout and functionality |
 
-## Option 1: Moving Settings to a Different Base Path
+## Option 1: Moving Account Views to a Different Base Path
 
-If you want to keep the built-in settings functionality but move it to a different location (e.g., from `/auth/settings` to `/dashboard/settings`), use the `settings.basePath` option:
+If you want to keep the built-in account functionality but move it to a different location (e.g., from `/account/settings` to `/dashboard/settings`), use the `account.basePath` option:
 
 ```tsx title="app/providers.tsx"
 "use client"
@@ -47,8 +47,8 @@ export function Providers({ children }: { children: React.ReactNode }) {
             navigate={router.push}
             replace={router.replace}
             onSessionChange={() => router.refresh()}
-            settings={{
-                basePath: "/dashboard" // Settings views will be at /dashboard/settings, /dashboard/security, etc.
+            account={{
+                basePath: "/dashboard" // Account views will be at /dashboard/settings, /dashboard/security, etc.
             }}
             Link={Link}
         >
@@ -60,97 +60,90 @@ export function Providers({ children }: { children: React.ReactNode }) {
 
 With this configuration:
 - Auth views remain at: `/auth/sign-in`, `/auth/sign-up`, etc.
-- Settings views move to: `/dashboard/settings`, `/dashboard/security`, `/dashboard/api-keys`, `/dashboard/organization`, etc.
-- The `<UserButton />` and `<SettingsCards />` components automatically use the new base path
+- Account views move to: `/dashboard/settings`, `/dashboard/security`, `/dashboard/api-keys`, `/dashboard/organizations`
+- The `<UserButton />` component automatically uses the new base path for the settings link
 
-You can combine `basePath` with other settings options:
+You can combine `basePath` with other account options:
 
 ```tsx
-settings={{
+account={{
     basePath: "/dashboard",
-    fields: ["image", "name", "age"] // Specify which fields to show
+    fields: ["image", "name", "age"] // Specify which fields to show in account settings
 }}
 ```
-### Using SettingsCards with pathname
 
-When using `settings.basePath`, you can pass the `pathname` prop to `<SettingsCards />` to automatically determine the current view:
+### Using AccountView with pathname
 
-```tsx title="app/dashboard/[...settings]/page.tsx"
-import { SettingsCards } from "@daveyplate/better-auth-ui"
+When using `account.basePath`, you can pass the `pathname` prop to `<AccountView />` to automatically determine the current view:
 
-export default function SettingsPage({ 
-    params 
-}: { 
-    params: { settings: string[] } 
+```tsx title="app/dashboard/[...account]/page.tsx"
+import { AccountView } from "@daveyplate/better-auth-ui"
+
+export default function AccountPage({
+    params
+}: {
+    params: { account: string[] }
 }) {
-    const pathname = `/dashboard/${params.settings?.join("/") || "settings"}`
-    
+    const pathname = `/dashboard/${params.account?.join("/") || "settings"}`
+
     return (
         <div className="mx-auto max-w-4xl py-12 px-4">
-            <SettingsCards pathname={pathname} />
+            <AccountView pathname={pathname} />
         </div>
     )
 }
 ```
 
-## Option 2: Completely Custom Settings Page
+## Option 2: Using the AccountView Component
 
-To replace the built-in settings with your own custom implementation, use `settings.url`:
+The `<AccountView />` component provides the complete account management UI with sidebar navigation. You can use it on any custom route:
 
-```tsx title="app/providers.tsx"
-"use client"
+```tsx title="app/dashboard/account/page.tsx"
+import { AccountView } from "@daveyplate/better-auth-ui"
 
-import { AuthUIProvider } from "@daveyplate/better-auth-ui"
-import { authClient } from "@/lib/auth-client"
-import { useRouter } from "next/navigation"
-import Link from "next/link"
-
-export function Providers({ children }: { children: React.ReactNode }) {
-    const router = useRouter()
-
+export default function CustomAccountPage() {
     return (
-        <AuthUIProvider
-            authClient={authClient}
-            navigate={router.push}
-            replace={router.replace}
-            onSessionChange={() => router.refresh()}
-            settings={{
-                url: "/my-custom-settings" // Redirects to your custom settings page
-            }}
-            Link={Link}
-        >
-            {children}
-        </AuthUIProvider>
+        <div className="container mx-auto py-12 px-4">
+            <AccountView />
+        </div>
     )
 }
 ```
 
-> **Important**: When `settings.url` is set, all built-in settings routes will redirect to your custom URL. You're responsible for implementing the entire settings functionality.
+The `<AccountView />` component automatically:
+- Renders a sidebar navigation for switching between Settings, Security, API Keys, and Organizations
+- Displays the appropriate content based on the current view
+- Handles responsive layouts (drawer menu on mobile, sidebar on desktop)
+- Protects the page (redirects to sign-in if not authenticated)
 
 ## Option 3: Building Custom Settings Layouts
 
 For maximum control, you can build your own settings page layouts using individual components.
 
-### Using Individual Settings Components
+### Using Settings Card Components
 
-The easiest way to get started is using the `<SettingsCards />` component, which automatically handles displaying all enabled settings. This includes avatar, email, username, password, linked social providers, session management, delete account, and custom additional fields you've provided.
+You can use the pre-built card components to compose your own settings layouts:
+
+- **`<AccountSettingsCards />`** - Displays all account-related settings (avatar, name, username, email, additional fields)
+- **`<SecuritySettingsCards />`** - Displays security settings (password, sessions, two-factor, passkeys, delete account)
 
 ```tsx title="app/dashboard/settings/page.tsx"
-import { SettingsCards } from "@daveyplate/better-auth-ui"
+import { AccountSettingsCards, SecuritySettingsCards } from "@daveyplate/better-auth-ui"
 
 export default function UserSettingsPage() {
     return (
-        <div className="mx-auto max-w-xl py-12 px-4">
-            <SettingsCards />
+        <div className="mx-auto max-w-xl py-12 px-4 space-y-6">
+            <AccountSettingsCards />
+            <SecuritySettingsCards />
         </div>
     )
 }
 ```
 
-You can customize the appearance using TailwindCSS classes through `classNames` props as documented in [SettingsCards](../components/settings-cards) documentation:
+You can customize the appearance using TailwindCSS classes through `classNames` props:
 
 ```tsx
-<SettingsCards 
+<AccountSettingsCards
     className="mx-auto max-w-xl"
     classNames={{
         card: {
@@ -241,18 +234,17 @@ This example assumes `additionalFields` are configured via your `<AuthUIProvider
             type: "number"
         }
     }}
-    settings={{
-        fields: ["age"],
-        url: "/dashboard/settings"
+    account={{
+        fields: ["image", "name", "age"] // Include custom fields in account settings
     }}
 >
     {children}
 </AuthUIProvider>
 ```
 
-## Handling Authentication for Settings Page
+## Handling Authentication for Account Pages
 
-It's essential that your custom settings page is protected and accessible only by authenticated users. There's a built-in helper `useAuthenticate` to ensure your settings pages are secured:
+It's essential that your custom account/settings pages are protected and accessible only by authenticated users. You can use the `<RedirectToSignIn />` and `<SignedIn>` components to ensure your pages are secured:
 
 ### Example:
 
@@ -260,18 +252,22 @@ It's essential that your custom settings page is protected and accessible only b
 import {
     RedirectToSignIn,
     SignedIn,
-    SettingsCards
+    AccountSettingsCards
 } from "@daveyplate/better-auth-ui"
 
 export default function CustomSettingsPage() {
     return (
         <>
             <RedirectToSignIn />
-            
+
             <SignedIn>
-                <SettingsCards />
+                <div className="container mx-auto py-12 px-4">
+                    <AccountSettingsCards />
+                </div>
             </SignedIn>
         </>
     )
 }
 ```
+
+Note: The `<AccountView />` component already includes authentication protection, so you don't need to add `<RedirectToSignIn />` when using it.

--- a/docs/content/docs/components/auth-ui-provider.mdx
+++ b/docs/content/docs/components/auth-ui-provider.mdx
@@ -92,8 +92,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             provider: "google-recaptcha-v3",
             siteKey: "your-site-key",
           }}
-          settings={{
-            url: "/dashboard/settings"
+          account={{
+            basePath: "/dashboard",
+            fields: ["image", "name"]
           }}
           twoFactor={["otp", "totp"]}
           Link={Link}

--- a/docs/content/docs/components/settings-cards.mdx
+++ b/docs/content/docs/components/settings-cards.mdx
@@ -1,69 +1,47 @@
 ---
-title: <SettingsCards />
+title: <AccountSettingsCards />
 ---
 
-The `<SettingsCards />` component provides a convenient plug-and-play UI for managing user account settings. It includes a comprehensive suite of manageable account settings, such as changing passwords and email addresses, updating avatars, managing linked providers, handling active sessions, and more.
+The `<AccountSettingsCards />` component provides a convenient plug-and-play UI for managing user account information. It displays all account-related settings such as avatar, name, username, email, and any custom additional fields you've configured.
 
-This component automatically leverages all the features you have enabled via the [`<AuthUIProvider />`](/components/auth-ui-provider) and provides a seamless user settings UI out of the box.
+This component automatically leverages the account features you have enabled via the [`<AuthUIProvider />`](/components/auth-ui-provider) and provides a seamless account settings UI out of the box.
 
 <img alt="Settings Cards" src="/screenshots/settings-cards-dark.png" className="rounded-xl hidden dark:block w-lg mt-0 mb-0" />
 <img alt="Settings Cards" src="/screenshots/settings-cards-light.png" className="rounded-xl dark:hidden w-lg mt-0 mb-0" />
 
-## Default Settings Page Behavior
+## Using AccountSettingsCards
 
-By default, the built-in [`<AuthView />`](/components/auth-view) component automatically displays `<SettingsCards />` when the `/auth/settings` route is accessed. If you prefer to handle user settings on a custom route or component, you can override this behavior using the `settings.url` prop.
+The `<AccountSettingsCards />` component is perfect for building custom account/settings pages. It can be used standalone or combined with other settings components:
 
-## Overriding Built-in Settings URL 
-
-To use your own custom settings route and avoid using the default included settings card, you can specify the `settings.url` prop within your [`<AuthUIProvider />`](/components/auth-ui-provider) configuration:
-
-```tsx title="app/providers.tsx"
-import { AuthUIProvider } from "@daveyplate/better-auth-ui"
-import { authClient } from "@/lib/auth-client"
-import { useRouter } from "next/navigation"
-import Link from "next/link"
-
-export function Providers({ children }: { children: React.ReactNode }) {
-    const router = useRouter()
-
-    return (
-        <AuthUIProvider
-            authClient={authClient}
-            navigate={router.push}
-            replace={router.replace}
-            onSessionChange={() => router.refresh()}
-            settings={{
-                url: "/dashboard/settings"  // Your custom settings page URL
-            }}
-            Link={Link}
-        >
-            {children}
-        </AuthUIProvider>
-    )
-}
-```
-
-By setting the `settings.url` as shown above, the built-in `/auth/settings` page will also automatically redirect users to your specified `/dashboard/settings` page.
-
----
-
-## Using `<SettingsCards />` on Your Custom Page
-
-You can then easily utilize the provided `<SettingsCards />` component directly in your custom settings route within your app's layout. Here's how you might set up a properly protected custom settings route in your framework of choice:
-
-```tsx title="app/dashboard/settings/page.tsx"
-import { SettingsCards } from "@daveyplate/better-auth-ui"
+```tsx title="app/account/settings/page.tsx"
+import { AccountSettingsCards } from "@daveyplate/better-auth-ui"
 
 export default function SettingsPage() {
   return (
     <div className="flex justify-center py-12 px-4">
-      <SettingsCards className="max-w-xl" />
+      <AccountSettingsCards className="max-w-xl" />
     </div>
   )
 }
 ```
 
-This will provide users a customizable, fully-styled settings experience without requiring you to create all components yourself.
+---
+
+## Using with AccountView
+
+For a complete account management UI with navigation, use the [`<AccountView />`](/components/account-view) component instead. It includes `<AccountSettingsCards />` along with security settings, API keys, and organizations (if enabled):
+
+```tsx title="app/account/page.tsx"
+import { AccountView } from "@daveyplate/better-auth-ui"
+
+export default function AccountPage() {
+  return (
+    <div className="container mx-auto py-12 px-4">
+      <AccountView />
+    </div>
+  )
+}
+```
 
 ---
 
@@ -76,7 +54,7 @@ You can customize the UI extensively by passing TailwindCSS classes or customizi
 Using Tailwind utility classes, you can fully customize all card states. Here's an example to illustrate significant styling customization:
 
 ```tsx
-<SettingsCards
+<AccountSettingsCards
   className="max-w-xl mx-auto"
   classNames={{
     card: {
@@ -93,20 +71,18 @@ Using Tailwind utility classes, you can fully customize all card states. Here's 
 />
 ```
 
-### All available settings included in SettingsCards: 
+### Settings Included in AccountSettingsCards
 
-- **Avatar** (optional, requires avatar upload configured in AuthUIProvider)
-- **Name**
-- **Email**
-- **Username** (requires username plugin)
-- **Password** (optional, requires credentials to be enabled)
-- **Connected Providers** (if enabled)
-- **Active Sessions**
-- **Delete Account** (optional, requires account deletion configuration)
+- **Avatar** (if `avatar` prop is configured in AuthUIProvider)
+- **Username** (if username plugin is enabled via `credentials.username`)
+- **Name** (if included in `account.fields`)
+- **Email** (if `changeEmail` is enabled)
+- **Additional Custom Fields** (any fields specified in `account.fields`)
+- **Accounts** (if multi-session is enabled)
 
 #### Custom Additional Fields
 
-The `<SettingsCards />` also supports displaying any custom `additionalFields` you've provided via the `settings.fields` prop of the `<AuthUIProvider />`:
+The `<AccountSettingsCards />` component displays any custom `additionalFields` you've configured via the `account.fields` prop of the `<AuthUIProvider />`:
 
 ```tsx title="app/providers.tsx"
 <AuthUIProvider
@@ -126,14 +102,14 @@ The `<SettingsCards />` also supports displaying any custom `additionalFields` y
       type: "boolean",
     }
   }}
-  settings={{
-    fields: ["age", "newsletter"]
+  account={{
+    fields: ["image", "name", "age", "newsletter"]
   }}
 >
   {children}
 </AuthUIProvider>
 ```
 
-These fields appear alongside the existing provided setting cards automatically.
+These custom fields will appear alongside the existing account setting cards automatically.
 
 ---


### PR DESCRIPTION
Enhance documentation for customizing authentication and account settings paths. Updated `custom-auth-paths.mdx` to clarify the use of `viewPaths` and `account.viewPaths` props, and added examples for configuring account settings. Renamed components from `SettingsCards` to `AccountSettingsCards` for consistency. Updated `custom-settings.mdx` and related files to reflect these changes.

