### PR TITLE
fix(CreateTeamDialog): make organizationId optional and integrate loc…

### DIFF
--- a/src/components/team/create-team-dialog.tsx
+++ b/src/components/team/create-team-dialog.tsx
@@ -32,7 +32,7 @@ import { Input } from "../ui/input"
 export interface CreateTeamDialogProps extends ComponentProps<typeof Dialog> {
     classNames?: SettingsCardClassNames
     localization?: AuthLocalization
-    organizationId: string
+    organizationId?: string
 }
 
 /**
@@ -46,7 +46,6 @@ export interface CreateTeamDialogProps extends ComponentProps<typeof Dialog> {
  * @returns A React element rendering the create-team dialog and its form.
  */
 export function CreateTeamDialog({
-    className,
     classNames,
     localization: localizationProp,
     organizationId,
@@ -56,6 +55,7 @@ export function CreateTeamDialog({
     const {
         authClient,
         localization: contextLocalization,
+        localizeErrors,
         toast
     } = useContext(AuthUIContext)
 
@@ -107,13 +107,13 @@ export function CreateTeamDialog({
         } catch (error) {
             toast({
                 variant: "error",
-                message: getLocalizedError({ error, localization })
+                message: getLocalizedError({ error, localization, localizeErrors })
             })
         }
     }
 
     return (
-        <Dialog onOpenChange={onOpenChange} className={className} {...props}>
+        <Dialog onOpenChange={onOpenChange} {...props}>
             <DialogContent className={classNames?.dialog?.content}>
                 <DialogHeader className={classNames?.dialog?.header}>
                     <DialogTitle


### PR DESCRIPTION
## Fix: Make organizationId optional and fix missing Localize errors prop

### Summary
This hotfix resolves build errors in the teams component by making the `organizationId` prop optional, adding missing `localizeErrors` prop and remove className prop from `<Dialog />`

### Changes
- **Made `organizationId` prop optional**: Changed from required `organizationId: string` to optional `organizationId?: string` in `CreateTeamDialogProps` interface
- **Integrated `localizeErrors` context**: Added `localizeErrors` from `AuthUIContext` to enable proper localization of backend error messages
- **Updated error handling**: Modified `getLocalizedError` call to include `localizeErrors` parameter for improved error message localization
- **Code cleanup**: Removed unused `className` prop from component since `<Dialog />` has no `className` prop

### Technical Details
The component already had proper handling for when `organizationId` is falsy:
- Early return in `onSubmit` function (line 88)
- Submit button disabled when `organizationId` is not provided (line 182)

### Impact
- Fixes build errors related to required `organizationId` prop
- Improves error message localization for backend errors
- Maintains backward compatibility (existing usage with required `organizationId` still works)

### Files Changed
- `src/components/team/create-team-dialog.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error messages in team creation dialogs are now properly localized based on user language settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->