### PR TITLE
fix: migrated account-info to a GET request

### DIFF
--- a/src/lib/auth-ui-provider.tsx
+++ b/src/lib/auth-ui-provider.tsx
@@ -586,8 +586,12 @@ export const AuthUIProvider = ({
                 }),
             useAccountInfo: (params) =>
                 useAuthData({
-                    queryFn: () => authClient.accountInfo(params),
-                    cacheKey: `accountInfo:${JSON.stringify(params)}`
+                queryFn: () =>
+                    authClient.$fetch("/account-info", {
+                    method: "GET",
+                    query: params,
+                    }),
+                cacheKey: `accountInfo:${JSON.stringify(params)}`,
                 }),
             useListDeviceSessions: () =>
                 useAuthData({


### PR DESCRIPTION
With the 1.4 update, better-auth deprecated using a POST request to the account-info route. The updated method uses a GET request, as highlighted [here](https://arc.net/l/quote/fyiqzsru).

This means that whenever users look at their third-party providers, they run into an error due to the failed POST request. This update fixes that by making changes to the useAccountInfo hook in following file:

- `lib/auth-ui-provider`

<img width="558" height="251" alt="Screenshot 2025-11-27 at 10 12 03 AM" src="https://github.com/user-attachments/assets/f3c7061c-ae8c-4743-9233-15807a3a489b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal data retrieval mechanisms for account information to improve code consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->