### PR TITLE
Remove the old avatar resource when updating avatar

### DIFF
--- a/src/components/settings/account/update-avatar-card.tsx
+++ b/src/components/settings/account/update-avatar-card.tsx
@@ -63,10 +63,6 @@ export function UpdateAvatarCard({
 
         if (avatar.upload) {
             image = await avatar.upload(resizedFile)
-            // If a custom storage remover is provided, clean up the old asset
-            if (sessionData.user.image && avatar.delete) {
-                await avatar.delete(sessionData.user.image)
-            }
         } else {
             image = await fileToBase64(resizedFile)
         }
@@ -81,6 +77,14 @@ export function UpdateAvatarCard({
         try {
             await updateUser({ image })
             await refetch?.()
+            // If a custom storage remover is provided, clean up the old asset
+            if (avatar.upload && avatar.delete && sessionData.user.image) {
+                try {
+                    await avatar.delete(sessionData.user.image)
+                } catch (error) {
+                    console.error("Failed to delete old avatar:", error)
+                }
+            }
         } catch (error) {
             toast({
                 variant: "error",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * After successfully uploading a new avatar, the previous avatar is now removed when available.
  * Failures during removal are caught and logged so they won't interrupt the successful upload flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->