### PR TITLE
Update dynamic route segment path in Next.js docs

### DIFF
--- a/docs/content/docs/integrations/next-js.mdx
+++ b/docs/content/docs/integrations/next-js.mdx
@@ -81,7 +81,7 @@ The [`<AuthUIProvider />`](/components/auth-ui-provider) can be fully customized
 <Step>
 ### Auth Pages
 
-Create a dynamic route segment for authentication views in `app/auth/[authView]/page.tsx`.
+Create a dynamic route segment for authentication views in `app/auth/[path]/page.tsx`.
 
 ```tsx title="app/auth/[path]/page.tsx"
 import { AuthView } from "@daveyplate/better-auth-ui"


### PR DESCRIPTION
This pull request updates the documentation for integrating authentication pages in a Next.js app. The main change is a correction to the dynamic route segment used for authentication views.

Documentation update:

* Changed the recommended dynamic route segment from `[authView]` to `[path]` in the example for authentication views in `app/auth/[path]/page.tsx` to better align with Next.js conventions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Next.js integration documentation examples to reflect dynamic route parameter naming changes for authentication pages across both App Router and Pages Router configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->