### PR TITLE
Add AuthView socialPlacement option

### DIFF
--- a/docs/content/docs/components/auth-view.mdx
+++ b/docs/content/docs/components/auth-view.mdx
@@ -30,6 +30,14 @@ Customize the navigation after successful authentication using the `redirectTo` 
 <AuthView redirectTo="/dashboard" />
 ```
 
+### Put Social Buttons First
+
+Render single sign-on buttons before the form by setting `socialPlacement` to `"before"`:
+
+```tsx
+<AuthView socialPlacement="before" />
+```
+
 ## Localization
 
 You can pass custom localization texts to fit different languages or contexts:


### PR DESCRIPTION
## Summary
- add `socialPlacement` prop to `AuthView` so integrators can optionally render social/SSO buttons before the form (default stays form-first)
- refactor rendering to order prebuilt sections and remove duplication
- document the new prop with a usage example

## Motivation
- many auth UIs (e.g., Notion, Attio, Cursor) surface SSO buttons first to nudge federated login; this adds the same flexibility without changing existing behavior
- keeps backward compatibility: if unset, the form still renders above social buttons

## Testing
- pnpm lint:fix
- pnpm turbo build (still fails earlier on pre-existing DTS issue: `passkeyClient` not exported in dependency; unrelated to this change)

## Notes
- Screenshots of SSO-first layouts (Notion, Attio, Cursor) available if reviewers want visual references.
