### PR TITLE
add emptyState prop to OrganizationInvitationsCard

### DIFF
--- a/src/components/organization/organization-invitations-card.tsx
+++ b/src/components/organization/organization-invitations-card.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import type { Organization } from "better-auth/plugins/organization"
-import { useContext, useMemo } from "react"
+import { type ReactNode, useContext, useMemo } from "react"
 import { useCurrentOrganization } from "../../hooks/use-current-organization"
 import { AuthUIContext } from "../../lib/auth-ui-provider"
 import { cn } from "../../lib/utils"
@@ -10,13 +10,19 @@ import { SettingsCard } from "../settings/shared/settings-card"
 import { CardContent } from "../ui/card"
 import { InvitationCell } from "./invitation-cell"
 
+export interface OrganizationInvitationsCardProps extends SettingsCardProps {
+    slug?: string
+    emptyState?: ReactNode
+}
+
 export function OrganizationInvitationsCard({
     className,
     classNames,
     localization: localizationProp,
     slug: slugProp,
+    emptyState,
     ...props
-}: SettingsCardProps & { slug?: string }) {
+}: OrganizationInvitationsCardProps) {
     const {
         localization: contextLocalization,
         organization: organizationOptions
@@ -49,8 +55,9 @@ function OrganizationInvitationsContent({
     classNames,
     localization: localizationProp,
     organization,
+    emptyState,
     ...props
-}: SettingsCardProps & { organization: Organization }) {
+}: SettingsCardProps & { organization: Organization; emptyState?: ReactNode }) {
     const {
         hooks: { useListInvitations },
         localization: contextLocalization
@@ -68,7 +75,7 @@ function OrganizationInvitationsContent({
     const pendingInvitations = invitations?.filter(
         (invitation) => invitation.status === "pending"
     )
-    if (!pendingInvitations?.length) return null
+    if (!pendingInvitations?.length) return <>{emptyState}</>
 
     return (
         <SettingsCard


### PR DESCRIPTION
I like to use the OrganizationInvitationsCard because better-auth-ui handles using the better-auth hooks, state and etc. for me, but for example if i need to add an empty state when there are no invites, i need to copy some of the same code that this component uses inside of it and start calling "useListInvitations" from the outer component, then rendering the invitations card conditionally, something like that.

I think receiving an empty state from the library user would be a good solution. this would be useful for other components as well. About how we could do this, i see two possible ways:

- simple emptyState: React.ReactNode prop
- composition pattern:

```tsx
<OrganizationInvitationsCard>
  <OrganizationInvitationsCard.EmptyState>
     <h2>You have no invites</h2>
     <EmptyStateIcon />
  </OrganizationInvitationsCard.EmptyState>
</OrganizationInvitationsCard>
```

I don't have a preference here but the concept of specifying the empty states seems nice to me. wyt?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
* Organization invitations card now supports customizable empty state messaging, allowing tailored content to display when no pending invitations are available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->