### PR TITLE
fix: add placeholder baseURL to prevent crashes in Tauri/Electron

### DIFF
--- a/src/components/settings/teams/user-team-cell.tsx
+++ b/src/components/settings/teams/user-team-cell.tsx
@@ -6,7 +6,6 @@ import { useContext, useState } from "react"
 import { AuthUIContext } from "../../../lib/auth-ui-provider"
 import { cn, getLocalizedError } from "../../../lib/utils"
 import type { AuthLocalization } from "../../../localization/auth-localization"
-import { authClient } from "../../../types/auth-client"
 import type { Refetch } from "../../../types/refetch"
 import { Button } from "../../ui/button"
 import { Card } from "../../ui/card"
@@ -28,6 +27,7 @@ export function UserTeamCell({
     refetch
 }: UserTeamCellProps) {
     const {
+        authClient,
         hooks: { useSession },
         localization: contextLocalization,
         toast,

--- a/src/types/auth-client.ts
+++ b/src/types/auth-client.ts
@@ -14,6 +14,11 @@ import {
 import { createAuthClient } from "better-auth/react"
 
 export const authClient = createAuthClient({
+    // Provide a placeholder baseURL to prevent errors in non-HTTP environments
+    // (e.g., Tauri, Electron where window.location.origin is tauri:// or file://)
+    // This client is only used for type inference and should not be used at runtime.
+    // See: https://github.com/better-auth-ui/better-auth-ui/issues/313
+    baseURL: "http://localhost",
     plugins: [
         apiKeyClient(),
         multiSessionClient(),


### PR DESCRIPTION
## Summary

This PR fixes #313 - the library crashes in Tauri and Electron apps with:
```
BetterAuthError: Invalid base URL: tauri://localhost. URL must include 'http://' or 'https://'
```

## Changes

### 1. Add placeholder baseURL to type-inference client (`src/types/auth-client.ts`)

The internal `authClient` was created without a `baseURL`, causing `better-auth`'s `getBaseURL()` to fall back to `window.location.origin`. In Tauri/Electron production builds, `window.location.origin` is `tauri://localhost` or `file://...`, which causes the error.

Since this client is only used for type inference and should not be used at runtime, adding a placeholder `baseURL` is safe and prevents the crash.

### 2. Fix UserTeamCell to use context authClient (`src/components/settings/teams/user-team-cell.tsx`)

The component was importing and using the type-inference `authClient` directly instead of getting it from `AuthUIContext`. This is a bug - the component should use the user-provided authClient from context like other components do.

## Testing

- Minimal reproduction repo: https://github.com/sawy/better-auth-ui-tauri-repro
- Tested locally with a Tauri v2 production build

## Related

- Issue: #313
- Reproduction: https://github.com/sawy/better-auth-ui-tauri-repro

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated authentication client initialization with environment-specific configuration support to better accommodate different application frameworks and platforms, improving deployment flexibility across various runtime environments.

* **Refactor**
  * Optimized internal authentication context access patterns to streamline component integration and improve overall code maintainability while ensuring consistent authentication client availability throughout the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->