### PR TITLE
Add `method="POST"` to all form elements

### DIFF
--- a/src/components/auth/forms/email-otp-form.tsx
+++ b/src/components/auth/forms/email-otp-form.tsx
@@ -123,6 +123,7 @@ function EmailForm({
     return (
         <Form {...form}>
             <form
+                method="POST"
                 onSubmit={form.handleSubmit(sendEmailOTP)}
                 noValidate={isHydrated}
                 className={cn("grid w-full gap-6", className, classNames?.base)}
@@ -253,6 +254,7 @@ export function OTPForm({
     return (
         <Form {...form}>
             <form
+                method="POST"
                 onSubmit={form.handleSubmit(verifyCode)}
                 className={cn("grid w-full gap-6", className, classNames?.base)}
             >

--- a/src/components/auth/forms/email-verification-form.tsx
+++ b/src/components/auth/forms/email-verification-form.tsx
@@ -186,6 +186,7 @@ export function EmailVerificationForm({
     return (
         <Form {...form}>
             <form
+                method="POST"
                 onSubmit={form.handleSubmit(verifyCode)}
                 className={cn("grid w-full gap-6", className, classNames?.base)}
             >

--- a/src/components/auth/forms/forgot-password-form.tsx
+++ b/src/components/auth/forms/forgot-password-form.tsx
@@ -118,6 +118,7 @@ export function ForgotPasswordForm({
     return (
         <Form {...form}>
             <form
+                method="POST"
                 onSubmit={form.handleSubmit(forgotPassword)}
                 noValidate={isHydrated}
                 className={cn("grid w-full gap-6", className, classNames?.base)}

--- a/src/components/auth/forms/magic-link-form.tsx
+++ b/src/components/auth/forms/magic-link-form.tsx
@@ -141,6 +141,7 @@ export function MagicLinkForm({
     return (
         <Form {...form}>
             <form
+                method="POST"
                 onSubmit={form.handleSubmit(sendMagicLink)}
                 noValidate={isHydrated}
                 className={cn("grid w-full gap-6", className, classNames?.base)}

--- a/src/components/auth/forms/recover-account-form.tsx
+++ b/src/components/auth/forms/recover-account-form.tsx
@@ -94,6 +94,7 @@ export function RecoverAccountForm({
     return (
         <Form {...form}>
             <form
+                method="POST"
                 onSubmit={form.handleSubmit(verifyBackupCode)}
                 className={cn("grid gap-6", className, classNames?.base)}
             >

--- a/src/components/auth/forms/reset-password-form.tsx
+++ b/src/components/auth/forms/reset-password-form.tsx
@@ -142,6 +142,7 @@ export function ResetPasswordForm({
     return (
         <Form {...form}>
             <form
+                method="POST"
                 onSubmit={form.handleSubmit(resetPassword)}
                 className={cn("grid w-full gap-6", className, classNames?.base)}
             >

--- a/src/components/auth/forms/sign-in-form.tsx
+++ b/src/components/auth/forms/sign-in-form.tsx
@@ -181,6 +181,7 @@ export function SignInForm({
     return (
         <Form {...form}>
             <form
+                method="POST"
                 onSubmit={form.handleSubmit(signIn)}
                 noValidate={isHydrated}
                 className={cn("grid w-full gap-6", className, classNames?.base)}

--- a/src/components/auth/forms/sign-up-form.tsx
+++ b/src/components/auth/forms/sign-up-form.tsx
@@ -424,6 +424,7 @@ export function SignUpForm({
     return (
         <Form {...form}>
             <form
+                method="POST"
                 onSubmit={form.handleSubmit(signUp)}
                 noValidate={isHydrated}
                 className={cn("grid w-full gap-6", className, classNames?.base)}

--- a/src/components/auth/forms/two-factor-form.tsx
+++ b/src/components/auth/forms/two-factor-form.tsx
@@ -199,6 +199,7 @@ export function TwoFactorForm({
     return (
         <Form {...form}>
             <form
+                method="POST"
                 onSubmit={form.handleSubmit(verifyCode)}
                 className={cn("grid w-full gap-6", className, classNames?.base)}
             >

--- a/src/components/organization/create-organization-dialog.tsx
+++ b/src/components/organization/create-organization-dialog.tsx
@@ -213,6 +213,7 @@ export function CreateOrganizationDialog({
 
                 <Form {...form}>
                     <form
+                        method="POST"
                         onSubmit={form.handleSubmit(onSubmit)}
                         className="space-y-6"
                     >

--- a/src/components/organization/create-team-dialog.tsx
+++ b/src/components/organization/create-team-dialog.tsx
@@ -139,6 +139,7 @@ export function CreateTeamDialog({
 
                 <Form {...form}>
                     <form
+                        method="POST"
                         onSubmit={form.handleSubmit(onSubmit)}
                         className="space-y-6"
                     >

--- a/src/components/organization/delete-organization-dialog.tsx
+++ b/src/components/organization/delete-organization-dialog.tsx
@@ -143,6 +143,7 @@ export function DeleteOrganizationDialog({
 
                 <Form {...form}>
                     <form
+                        method="POST"
                         onSubmit={form.handleSubmit(deleteOrganization)}
                         className="grid gap-6"
                     >

--- a/src/components/organization/invite-member-dialog.tsx
+++ b/src/components/organization/invite-member-dialog.tsx
@@ -178,6 +178,7 @@ export function InviteMemberDialog({
 
                 <Form {...form}>
                     <form
+                        method="POST"
                         onSubmit={form.handleSubmit(onSubmit)}
                         className="space-y-6"
                     >

--- a/src/components/organization/organization-name-card.tsx
+++ b/src/components/organization/organization-name-card.tsx
@@ -153,7 +153,7 @@ function OrganizationNameForm({
 
     return (
         <Form {...form}>
-            <form onSubmit={form.handleSubmit(updateOrganizationName)}>
+            <form method="POST" onSubmit={form.handleSubmit(updateOrganizationName)}>
                 <SettingsCard
                     className={className}
                     classNames={classNames}

--- a/src/components/organization/organization-slug-card.tsx
+++ b/src/components/organization/organization-slug-card.tsx
@@ -172,7 +172,7 @@ function OrganizationSlugForm({
 
     return (
         <Form {...form}>
-            <form onSubmit={form.handleSubmit(updateOrganizationSlug)}>
+            <form method="POST" onSubmit={form.handleSubmit(updateOrganizationSlug)}>
                 <SettingsCard
                     className={className}
                     classNames={classNames}

--- a/src/components/settings/account/delete-account-dialog.tsx
+++ b/src/components/settings/account/delete-account-dialog.tsx
@@ -163,6 +163,7 @@ export function DeleteAccountDialog({
 
                 <Form {...form}>
                     <form
+                        method="POST"
                         onSubmit={form.handleSubmit(deleteAccount)}
                         className="grid gap-6"
                     >

--- a/src/components/settings/account/update-field-card.tsx
+++ b/src/components/settings/account/update-field-card.tsx
@@ -178,7 +178,7 @@ export function UpdateFieldCard({
 
     return (
         <Form {...form}>
-            <form onSubmit={form.handleSubmit(updateField)}>
+            <form method="POST" onSubmit={form.handleSubmit(updateField)}>
                 <SettingsCard
                     className={className}
                     classNames={classNames}

--- a/src/components/settings/api-key/create-api-key-dialog.tsx
+++ b/src/components/settings/api-key/create-api-key-dialog.tsx
@@ -179,6 +179,7 @@ export function CreateApiKeyDialog({
 
                 <Form {...form}>
                     <form
+                        method="POST"
                         onSubmit={form.handleSubmit(onSubmit)}
                         className="space-y-6"
                     >

--- a/src/components/settings/passkey/passkeys-card.tsx
+++ b/src/components/settings/passkey/passkeys-card.tsx
@@ -81,7 +81,7 @@ export function PasskeysCard({
             />
 
             <Form {...form}>
-                <form onSubmit={form.handleSubmit(addPasskey)}>
+                <form method="POST" onSubmit={form.handleSubmit(addPasskey)}>
                     <SettingsCard
                         className={className}
                         classNames={classNames}

--- a/src/components/settings/security/change-email-card.tsx
+++ b/src/components/settings/security/change-email-card.tsx
@@ -128,7 +128,7 @@ export function ChangeEmailCard({
     return (
         <>
             <Form {...form}>
-                <form noValidate onSubmit={form.handleSubmit(changeEmail)}>
+                <form method="POST" noValidate onSubmit={form.handleSubmit(changeEmail)}>
                     <SettingsCard
                         className={className}
                         classNames={classNames}
@@ -184,6 +184,7 @@ export function ChangeEmailCard({
                 !sessionData?.user.emailVerified && (
                     <Form {...resendForm}>
                         <form
+                            method="POST"
                             onSubmit={resendForm.handleSubmit(
                                 resendVerification
                             )}

--- a/src/components/settings/security/change-password-card.tsx
+++ b/src/components/settings/security/change-password-card.tsx
@@ -178,7 +178,7 @@ export function ChangePasswordCard({
     if (!isPending && !credentialsLinked) {
         return (
             <Form {...setPasswordForm}>
-                <form onSubmit={setPasswordForm.handleSubmit(setPassword)}>
+                <form method="POST" onSubmit={setPasswordForm.handleSubmit(setPassword)}>
                     <SettingsCard
                         title={localization.SET_PASSWORD}
                         description={localization.SET_PASSWORD_DESCRIPTION}
@@ -194,7 +194,7 @@ export function ChangePasswordCard({
 
     return (
         <Form {...form}>
-            <form onSubmit={form.handleSubmit(changePassword)}>
+            <form method="POST" onSubmit={form.handleSubmit(changePassword)}>
                 <SettingsCard
                     className={className}
                     classNames={classNames}

--- a/src/components/settings/two-factor/two-factor-password-dialog.tsx
+++ b/src/components/settings/two-factor/two-factor-password-dialog.tsx
@@ -141,6 +141,7 @@ export function TwoFactorPasswordDialog({
 
                     <Form {...form}>
                         <form
+                            method="POST"
                             onSubmit={form.handleSubmit(
                                 isTwoFactorEnabled
                                     ? disableTwoFactor


### PR DESCRIPTION
## Summary
- Added `method="POST"` to all 25 `<form>` elements across 19 files
- Prevents form data from being written to URL query parameters on fallback submission
- Keeps sensitive fields (passwords, emails, OTP codes) out of browser history, server logs, and referrer headers

## Affected areas
- Auth forms (sign-in, sign-up, forgot/reset password, magic link, email OTP, email verification, two-factor, recover account)
- Organization forms (create org, create team, delete org, invite member, org name/slug)
- Settings forms (update field, delete account, change password, change email, passkeys, two-factor password, create API key)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated form submission methods across authentication, organization, and settings interfaces to use POST protocol for improved security and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->