### PR TITLE
Replace ua-parser-js with bowser (AGPL -> MIT)

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
         "@wojtekmaj/react-recaptcha-v3": "^0.1.4",
         "react-google-recaptcha": "^3.1.0",
         "react-qr-code": "^2.0.18",
-        "ua-parser-js": "^2.0.7",
+        "bowser": "^2.11.0",
         "vaul": "^1.1.2"
     },
     "packageManager": "pnpm@10.26.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       '@wojtekmaj/react-recaptcha-v3':
         specifier: ^0.1.4
         version: 0.1.4(@types/react@19.2.7)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      bowser:
+        specifier: ^2.11.0
+        version: 2.14.1
       input-otp:
         specifier: '>=1.4.0'
         version: 1.4.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -80,9 +83,6 @@ importers:
       tailwindcss:
         specifier: '>=3.0.0'
         version: 4.1.7
-      ua-parser-js:
-        specifier: ^2.0.7
-        version: 2.0.7
       vaul:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1568,6 +1568,9 @@ packages:
       zod:
         optional: true
 
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
+
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -1632,9 +1635,6 @@ packages:
 
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
-
-  detect-europe-js@0.1.2:
-    resolution: {integrity: sha512-lgdERlL3u0aUdHocoouzT10d9I89VVhk0qNRmll7mXdGfJT1/wqZ2ZLA4oJAjeACPY5fT1wsbq2AT+GkuInsow==}
 
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
@@ -1718,9 +1718,6 @@ packages:
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
-
-  is-standalone-pwa@0.1.1:
-    resolution: {integrity: sha512-9Cbovsa52vNQCjdXOzeQq5CnCbAcRk05aU62K20WO372NrTv0NxibLFCK6lQ4/iZEFdEA3p3t2VNOn8AJ53F5g==}
 
   is-what@4.1.16:
     resolution: {integrity: sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==}
@@ -2154,13 +2151,6 @@ packages:
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
-    hasBin: true
-
-  ua-is-frozen@0.1.2:
-    resolution: {integrity: sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw==}
-
-  ua-parser-js@2.0.7:
-    resolution: {integrity: sha512-CFdHVHr+6YfbktNZegH3qbYvYgC7nRNEUm2tk7nSFXSODUu4tDBpaFpP1jdXBUOKKwapVlWRfTtS8bCPzsQ47w==}
     hasBin: true
 
   ufo@1.6.1:
@@ -3428,6 +3418,8 @@ snapshots:
     optionalDependencies:
       zod: 4.2.1
 
+  bowser@2.14.1: {}
+
   bundle-require@5.1.0(esbuild@0.27.2):
     dependencies:
       esbuild: 0.27.2
@@ -3474,8 +3466,6 @@ snapshots:
   deepmerge@4.3.1: {}
 
   defu@6.1.4: {}
-
-  detect-europe-js@0.1.2: {}
 
   detect-node-es@1.1.0: {}
 
@@ -3590,8 +3580,6 @@ snapshots:
     dependencies:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
-
-  is-standalone-pwa@0.1.1: {}
 
   is-what@4.1.16: {}
 
@@ -3987,14 +3975,6 @@ snapshots:
       turbo-windows-arm64: 2.6.3
 
   typescript@5.9.3: {}
-
-  ua-is-frozen@0.1.2: {}
-
-  ua-parser-js@2.0.7:
-    dependencies:
-      detect-europe-js: 0.1.2
-      is-standalone-pwa: 0.1.1
-      ua-is-frozen: 0.1.2
 
   ufo@1.6.1: {}
 

--- a/src/components/settings/security/session-cell.tsx
+++ b/src/components/settings/security/session-cell.tsx
@@ -1,9 +1,9 @@
 "use client"
 
 import type { Session } from "better-auth"
+import Bowser from "bowser"
 import { LaptopIcon, Loader2, SmartphoneIcon } from "lucide-react"
 import { useContext, useState } from "react"
-import { UAParser } from "ua-parser-js"
 import { AuthUIContext } from "../../../lib/auth-ui-provider"
 import { cn, getLocalizedError } from "../../../lib/utils"
 import type { AuthLocalization } from "../../../localization/auth-localization"
@@ -70,8 +70,8 @@ export function SessionCell({
         }
     }
 
-    const parser = UAParser(session.userAgent as string)
-    const isMobile = parser.device.type === "mobile"
+    const parsed = session.userAgent ? Bowser.parse(session.userAgent) : null
+    const isMobile = parsed?.platform.type === "mobile"
 
     return (
         <Card
@@ -97,10 +97,10 @@ export function SessionCell({
                 <span className="text-muted-foreground text-xs">
                     {session.userAgent?.includes("tauri-plugin-http")
                         ? localization.APP
-                        : parser.os.name && parser.browser.name
-                          ? `${parser.os.name}, ${parser.browser.name}`
-                          : parser.os.name ||
-                            parser.browser.name ||
+                        : parsed?.os.name && parsed?.browser.name
+                          ? `${parsed.os.name}, ${parsed.browser.name}`
+                          : parsed?.os.name ||
+                            parsed?.browser.name ||
                             session.userAgent ||
                             localization.UNKNOWN}
                 </span>


### PR DESCRIPTION
## Summary

- Replaces `ua-parser-js` (AGPLv3 since v2.0.0) with `bowser` (MIT-licensed) to resolve the license incompatibility reported in #346
- `bowser` provides equivalent user-agent parsing (browser name, OS name, platform/device type) with a permissive license
- All existing functionality in `session-cell.tsx` is preserved with the same behavior

## Changes

- **`package.json`**: Swapped `ua-parser-js` dependency for `bowser@^2.11.0`
- **`session-cell.tsx`**: Updated import and parsing calls to use Bowser's API (`Bowser.parse()` instead of `UAParser()`)
- **`pnpm-lock.yaml`**: Updated lockfile

## Test plan

- [x] Project builds successfully (`pnpm build`)
- [x] Biome lint passes for modified file
- [ ] Verify session list renders correctly with browser/OS info
- [ ] Verify mobile device detection works properly

Fixes #346

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal dependencies to optimize session management and device detection functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->