### PR TITLE
fix(providers-card): filter out linked providers to prevent duplicates

### DIFF
--- a/src/components/settings/providers/providers-card.tsx
+++ b/src/components/settings/providers/providers-card.tsx
@@ -91,37 +91,50 @@ export function ProvidersCard({
                             )
                         })}
 
-                        {social?.providers?.map((provider) => {
-                            const socialProvider = socialProviders.find(
-                                (socialProvider) =>
-                                    socialProvider.provider === provider
+                        {social?.providers
+                            ?.filter(
+                                (provider) =>
+                                    !accounts?.some(
+                                        (acc) =>
+                                            acc.providerId === provider
+                                    )
                             )
+                            .map((provider) => {
+                                const socialProvider = socialProviders.find(
+                                    (socialProvider) =>
+                                        socialProvider.provider === provider
+                                )
 
-                            if (!socialProvider) return null
+                                if (!socialProvider) return null
 
-                            return (
+                                return (
+                                    <ProviderCell
+                                        key={provider}
+                                        classNames={classNames}
+                                        provider={socialProvider}
+                                        refetch={refetch}
+                                    />
+                                )
+                            })}
+
+                        {genericOAuth?.providers
+                            ?.filter(
+                                (provider) =>
+                                    !accounts?.some(
+                                        (acc) =>
+                                            acc.providerId ===
+                                            provider.provider
+                                    )
+                            )
+                            .map((provider) => (
                                 <ProviderCell
-                                    key={provider}
+                                    key={provider.provider}
                                     classNames={classNames}
-                                    provider={socialProvider}
+                                    provider={provider}
                                     refetch={refetch}
+                                    other
                                 />
-                            )
-                        })}
-
-                        {genericOAuth?.providers?.map((provider) => (
-                            <ProviderCell
-                                key={provider.provider}
-                                classNames={classNames}
-                                account={accounts?.find(
-                                    (acc) =>
-                                        acc.providerId === provider.provider
-                                )}
-                                provider={provider}
-                                refetch={refetch}
-                                other
-                            />
-                        ))}
+                            ))}
                     </>
                 )}
             </CardContent>


### PR DESCRIPTION
## Summary

Fixes #361

`ProvidersCard` renders duplicate entries when a provider is both linked (in `accounts` from DB) and configured (in `genericOAuth.providers` or `social.providers`).

- **Accounts loop** (1st) renders linked providers with account data
- **Social loop** (2nd) and **genericOAuth loop** (3rd) rendered all configured providers unconditionally — causing duplicates

### Fix

Both the social and genericOAuth loops now filter out providers that already have a linked account, so each provider renders exactly once:
- Linked providers → rendered by accounts loop (with account data, disconnect button)
- Unlinked providers → rendered by config loops (with connect button)

### Before/After

| Before | After |
|--------|-------|
| Linked genericOAuth provider shows twice (identical rows) | Shows once |
| Linked social provider shows as both "linked" and "connect" | Shows once as "linked" |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate provider options appearing for already-configured accounts in the settings page. Only unconfigured providers are now displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->