### PR TITLE
fix: Inline bowser in build; remove dependency

### DIFF
--- a/packages/heroui/package.json
+++ b/packages/heroui/package.json
@@ -61,8 +61,7 @@
     "@tanstack/react-query": ">=5.100.14",
     "better-auth": ">=1.6.11",
     "react": ">=19.2.6",
-    "react-dom": ">=19.2.6",
-    "bowser": ">=2.11.0"
+    "react-dom": ">=19.2.6"
   },
   "repository": {
     "type": "git",

--- a/packages/heroui/vite.config.ts
+++ b/packages/heroui/vite.config.ts
@@ -33,8 +33,12 @@ export default defineConfig({
       formats: ["es"]
     },
     rolldownOptions: {
-      // All bare module IDs (not starting with `.` or `/` or `C:\`)
-      external: /^[^./](?!:[/\\])/
+      // Externalize all bare module IDs (not starting with `.` or `/` or `C:\`),
+      // except `bowser`. Bowser ships a UMD `es5.js` via its `browser` field that
+      // does not expose a real ESM `default` export, so leaving it external breaks
+      // consumers using strict ESM resolvers (TanStack Start / Vite 7+ / Rolldown).
+      // Bundling it inline sidesteps the interop issue entirely.
+      external: (id) => id !== "bowser" && /^[^./](?!:[/\\])/.test(id)
     }
   }
 })


### PR DESCRIPTION
Bundle bowser into the package build instead of externalizing it. The Vite rollup external setting was changed from a regex to a function that excludes "bowser" to avoid ESM interop breakage caused by Bowser's UMD/es5 browser field (affects strict ESM resolvers like TanStack Start / Vite 7+ / Rollup). The package.json entry for bowser was removed because it is now included in the bundled output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency and build configuration for improved module bundling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/better-auth-ui/better-auth-ui/pull/402?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->