### PR TITLE
fix: Use 'src' export condition and resolve it

### DIFF
--- a/apps/docs/vite.config.ts
+++ b/apps/docs/vite.config.ts
@@ -25,7 +25,12 @@ export default defineConfig({
   },
   resolve: {
     tsconfigPaths: true,
-    noExternal: [...FumadocsDeps, "@gravity-ui/icons"]
+    noExternal: [...FumadocsDeps, "@gravity-ui/icons"],
+    // Resolve workspace `@better-auth-ui/*` packages to their `src/` entrypoints
+    // via the `src` export condition. `src` is a monorepo-private condition that
+    // no bundler matches by default, so it never leaks into external consumers'
+    // resolution.
+    conditions: ["src"]
   },
   plugins: [
     mdx(await import("./source.config")),

--- a/apps/heroui-dev/tsconfig.json
+++ b/apps/heroui-dev/tsconfig.json
@@ -9,7 +9,7 @@
 
     /* Bundler mode */
     "moduleResolution": "bundler",
-    "customConditions": ["development"],
+    "customConditions": ["src"],
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": false,
     "noEmit": true,

--- a/apps/heroui-dev/vite.config.ts
+++ b/apps/heroui-dev/vite.config.ts
@@ -11,7 +11,13 @@ const config = defineConfig({
   },
   resolve: {
     tsconfigPaths: true,
-    noExternal: ["@gravity-ui/icons"]
+    noExternal: ["@gravity-ui/icons"],
+    // Resolve workspace `@better-auth-ui/*` packages to their `src/` entrypoints
+    // via the `src` export condition for hot reload during local development.
+    // This mirrors `customConditions: ["src"]` in the monorepo's tsconfig and
+    // does NOT leak to external consumers, since `src` is not in any bundler's
+    // default condition list.
+    conditions: ["src"]
   },
   plugins: [
     cloudflare({ viteEnvironment: { name: "ssr" } }),

--- a/bun.lock
+++ b/bun.lock
@@ -329,6 +329,7 @@
         "@tanstack/react-pacer": ">=0.22.1",
         "@tanstack/react-query": ">=5.100.14",
         "better-auth": ">=1.6.11",
+        "bowser": ">=2.11.0",
         "react": ">=19.2.6",
         "react-dom": ">=19.2.6",
       },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,12 +14,12 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
+      "src": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
     "./plugins": {
-      "development": "./src/plugins.ts",
+      "src": "./src/plugins.ts",
       "types": "./dist/plugins.d.ts",
       "import": "./dist/plugins.js"
     }

--- a/packages/heroui/package.json
+++ b/packages/heroui/package.json
@@ -12,22 +12,22 @@
   ],
   "exports": {
     ".": {
-      "development": "./src/index.tsx",
+      "src": "./src/index.tsx",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
     "./email": {
-      "development": "./src/email.ts",
+      "src": "./src/email.ts",
       "types": "./dist/email.d.ts",
       "import": "./dist/email.js"
     },
     "./plugins": {
-      "development": "./src/plugins.ts",
+      "src": "./src/plugins.ts",
       "types": "./dist/plugins.d.ts",
       "import": "./dist/plugins.js"
     },
     "./styles": {
-      "development": "./src/styles.css",
+      "src": "./src/styles.css",
       "default": "./dist/styles.css"
     }
   },
@@ -61,7 +61,8 @@
     "@tanstack/react-query": ">=5.100.14",
     "better-auth": ">=1.6.11",
     "react": ">=19.2.6",
-    "react-dom": ">=19.2.6"
+    "react-dom": ">=19.2.6",
+    "bowser": ">=2.11.0"
   },
   "repository": {
     "type": "git",

--- a/packages/heroui/vite.config.ts
+++ b/packages/heroui/vite.config.ts
@@ -33,12 +33,8 @@ export default defineConfig({
       formats: ["es"]
     },
     rolldownOptions: {
-      // Externalize all bare module IDs (not starting with `.` or `/` or `C:\`),
-      // except `bowser`. Bowser ships a UMD `es5.js` via its `browser` field that
-      // does not expose a real ESM `default` export, so leaving it external breaks
-      // consumers using strict ESM resolvers (TanStack Start / Vite 7+ / Rolldown).
-      // Bundling it inline sidesteps the interop issue entirely.
-      external: (id) => id !== "bowser" && /^[^./](?!:[/\\])/.test(id)
+      // All bare module IDs (not starting with `.` or `/` or `C:\`)
+      external: /^[^./](?!:[/\\])/
     }
   }
 })

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -15,22 +15,22 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
+      "src": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
     "./email": {
-      "development": "./src/email.ts",
+      "src": "./src/email.ts",
       "types": "./dist/email.d.ts",
       "import": "./dist/email.js"
     },
     "./server": {
-      "development": "./src/server.ts",
+      "src": "./src/server.ts",
       "types": "./dist/server.d.ts",
       "import": "./dist/server.js"
     },
     "./plugins": {
-      "development": "./src/plugins.ts",
+      "src": "./src/plugins.ts",
       "types": "./dist/plugins.d.ts",
       "import": "./dist/plugins.js"
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "lib": ["esnext", "dom", "dom.iterable"],
     "module": "esnext",
     "moduleResolution": "bundler",
-    "customConditions": ["development"],
+    "customConditions": ["src"],
     "skipLibCheck": true,
     "strict": true,
     "target": "esnext",


### PR DESCRIPTION
Switch package export condition from "development" to a monorepo-private "src" across core, react, and heroui packages. Update tsconfig (root and apps/heroui-dev) to include customConditions: ["src"] and add resolve.conditions: ["src"] to Vite configs (apps/docs, apps/heroui-dev, packages/heroui) so the bundler resolves workspace @better-auth-ui/* packages to their src entrypoints for local development/hot-reload. Also add bowser to heroui's peer deps and simplify the package rollup external pattern (removed the previous special-case bundling for bowser). Comments clarify that the "src" condition is private and won't leak to external consumers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated module resolution configuration and export conditions across packages.
  * Added `bowser` (>=2.11.0) as a required peer dependency for the package.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/better-auth-ui/better-auth-ui/pull/403?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->