### PR TITLE
Fix: hide "Forgot password?" link when email/password auth is disabled

### DIFF
--- a/apps/docs/src/components/auth/sign-in.tsx
+++ b/apps/docs/src/components/auth/sign-in.tsx
@@ -302,7 +302,7 @@ export function SignIn({
         </div>
 
         <div className="flex flex-col gap-3 items-center w-full mt-4">
-          {emailAndPassword?.forgotPassword && (
+          {emailAndPassword?.enabled && emailAndPassword?.forgotPassword && (
             <Link
               href={`${basePaths.auth}/${viewPaths.auth.forgotPassword}`}
               className="self-center text-sm underline-offset-4 hover:underline"

--- a/apps/docs/src/components/auth/username/sign-in-username.tsx
+++ b/apps/docs/src/components/auth/username/sign-in-username.tsx
@@ -326,7 +326,7 @@ export function SignInUsername({
         </div>
 
         <div className="flex flex-col gap-3 items-center w-full mt-4">
-          {emailAndPassword?.forgotPassword && (
+          {emailAndPassword?.enabled && emailAndPassword?.forgotPassword && (
             <Link
               href={`${basePaths.auth}/${viewPaths.auth.forgotPassword}`}
               className="self-center text-sm underline-offset-4 hover:underline"

--- a/examples/next-shadcn-example/src/components/auth/sign-in.tsx
+++ b/examples/next-shadcn-example/src/components/auth/sign-in.tsx
@@ -302,7 +302,7 @@ export function SignIn({
         </div>
 
         <div className="flex flex-col gap-3 items-center w-full mt-4">
-          {emailAndPassword?.forgotPassword && (
+          {emailAndPassword?.enabled && emailAndPassword?.forgotPassword && (
             <Link
               href={`${basePaths.auth}/${viewPaths.auth.forgotPassword}`}
               className="self-center text-sm underline-offset-4 hover:underline"

--- a/examples/next-shadcn-example/src/components/auth/username/sign-in-username.tsx
+++ b/examples/next-shadcn-example/src/components/auth/username/sign-in-username.tsx
@@ -326,7 +326,7 @@ export function SignInUsername({
         </div>
 
         <div className="flex flex-col gap-3 items-center w-full mt-4">
-          {emailAndPassword?.forgotPassword && (
+          {emailAndPassword?.enabled && emailAndPassword?.forgotPassword && (
             <Link
               href={`${basePaths.auth}/${viewPaths.auth.forgotPassword}`}
               className="self-center text-sm underline-offset-4 hover:underline"

--- a/examples/start-shadcn-example/src/components/auth/sign-in.tsx
+++ b/examples/start-shadcn-example/src/components/auth/sign-in.tsx
@@ -302,7 +302,7 @@ export function SignIn({
         </div>
 
         <div className="flex flex-col gap-3 items-center w-full mt-4">
-          {emailAndPassword?.forgotPassword && (
+          {emailAndPassword?.enabled && emailAndPassword?.forgotPassword && (
             <Link
               href={`${basePaths.auth}/${viewPaths.auth.forgotPassword}`}
               className="self-center text-sm underline-offset-4 hover:underline"

--- a/examples/start-shadcn-example/src/components/auth/username/sign-in-username.tsx
+++ b/examples/start-shadcn-example/src/components/auth/username/sign-in-username.tsx
@@ -326,7 +326,7 @@ export function SignInUsername({
         </div>
 
         <div className="flex flex-col gap-3 items-center w-full mt-4">
-          {emailAndPassword?.forgotPassword && (
+          {emailAndPassword?.enabled && emailAndPassword?.forgotPassword && (
             <Link
               href={`${basePaths.auth}/${viewPaths.auth.forgotPassword}`}
               className="self-center text-sm underline-offset-4 hover:underline"

--- a/packages/heroui/src/components/auth/sign-in.tsx
+++ b/packages/heroui/src/components/auth/sign-in.tsx
@@ -260,7 +260,7 @@ export function SignIn({
       </Card.Content>
 
       <Card.Footer className="flex-col gap-3">
-        {emailAndPassword?.forgotPassword && (
+        {emailAndPassword?.enabled && emailAndPassword?.forgotPassword && (
           <Link
             href={`${basePaths.auth}/${viewPaths.auth.forgotPassword}`}
             className="no-underline hover:underline"

--- a/packages/heroui/src/components/auth/username/sign-in-username.tsx
+++ b/packages/heroui/src/components/auth/username/sign-in-username.tsx
@@ -288,7 +288,7 @@ export function SignInUsername({
       </Card.Content>
 
       <Card.Footer className="flex-col gap-3">
-        {emailAndPassword?.forgotPassword && (
+        {emailAndPassword?.enabled && emailAndPassword?.forgotPassword && (
           <Link
             href={`${basePaths.auth}/${viewPaths.auth.forgotPassword}`}
             className="no-underline hover:underline"


### PR DESCRIPTION
In this update, users do not need to fill in the enable and forgotPassword fields at the same time

### Problem
When emailAndPassword.enabled is set to false (e.g. social-only authentication), the "Forgot password?" link was still being rendered in the sign-in card.

This happens because the condition only checked emailAndPassword.forgotPassword (which defaults to true) without checking whether email/password auth itself was enabled.

**Fix**
Added emailAndPassword?.enabled as a guard condition before emailAndPassword?.forgotPassword in all sign-in components:

```
// Before
{emailAndPassword?.forgotPassword && (
// After
{emailAndPassword?.enabled && emailAndPassword?.forgotPassword && (
This way, setting enabled: false is enough to hide the link — users don't need to additionally set forgotPassword: false.
```

**Files Changed**
packages/heroui/src/components/auth/sign-in.tsx
packages/heroui/src/components/auth/username/sign-in-username.tsx
examples/next-shadcn-example/src/components/auth/sign-in.tsx
examples/next-shadcn-example/src/components/auth/username/sign-in-username.tsx
examples/start-shadcn-example/src/components/auth/sign-in.tsx
examples/start-shadcn-example/src/components/auth/username/sign-in-username.tsx
apps/docs/src/components/auth/sign-in.tsx
apps/docs/src/components/auth/username/sign-in-username.tsx

### Screenshots
<img width="787" height="380" alt="image" src="https://github.com/user-attachments/assets/39e1d249-f6b3-4385-bf6e-d8a56298d938" />
<img width="2390" height="482" alt="code" src="https://github.com/user-attachments/assets/308059c0-9443-47cd-898c-1ddd880fbcbd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the "forgot password" link could appear in sign-in forms even when email/password authentication was disabled. The link now only displays when the email/password authentication method is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->