### PR TITLE
ci(solid): build deps before Zaidan example tests

### DIFF
--- a/examples/start-solid-zaidan-example/package.json
+++ b/examples/start-solid-zaidan-example/package.json
@@ -2,6 +2,15 @@
   "name": "start-solid-zaidan-example",
   "private": true,
   "type": "module",
+  "nx": {
+    "targets": {
+      "test": {
+        "dependsOn": [
+          "^build"
+        ]
+      }
+    }
+  },
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",

--- a/examples/start-solid-zaidan-example/package.json
+++ b/examples/start-solid-zaidan-example/package.json
@@ -8,6 +8,11 @@
         "dependsOn": [
           "^build"
         ]
+      },
+      "typecheck": {
+        "dependsOn": [
+          "^build"
+        ]
       }
     }
   },

--- a/examples/start-solid-zaidan-example/src/components/auth/settings/security/change-password.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/settings/security/change-password.tsx
@@ -6,6 +6,7 @@ import {
   useSession
 } from "@better-auth-ui/solid"
 import { createMutation, createQuery } from "@tanstack/solid-query"
+import type { BetterFetchError } from "better-auth/client"
 import { Eye, EyeOff } from "lucide-solid"
 import { createSignal, Show } from "solid-js"
 import { toast } from "solid-sonner"
@@ -55,7 +56,7 @@ export function ChangePasswordSettings(
   }))
   const changePassword = createMutation(() => ({
     ...changePasswordOptions(auth.authClient),
-    onError: (error) => {
+    onError: (error: BetterFetchError) => {
       setCurrentPassword("")
       setNewPassword("")
       setConfirmPassword("")


### PR DESCRIPTION
Refs #426
Split from #427 per maintainer feedback.

## Type

- [x] Maintenance/tooling
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Breaking change

## Summary

This PR extracts the Solid/Zaidan CI/typecheck fix from #427 into a small standalone change.

- Makes `start-solid-zaidan-example:test` and `start-solid-zaidan-example:typecheck` build upstream workspace packages first in clean CI.
- Types the Solid/Zaidan change-password `onError` callback as `BetterFetchError` from `better-auth/client`.
- Does **not** include the query factory/core architecture refactor.

## Changes

| File | Change |
| --- | --- |
| `examples/start-solid-zaidan-example/package.json` | Adds scoped Nx `test.dependsOn: ["^build"]` and `typecheck.dependsOn: ["^build"]` so the example has built `@better-auth-ui/core` / `@better-auth-ui/solid` package outputs in clean CI. |
| `examples/start-solid-zaidan-example/src/components/auth/settings/security/change-password.tsx` | Types the `changePassword` mutation `onError` callback as `BetterFetchError` from `better-auth/client`. |

## Why

The failure surfaced while working on #427, but it is independent from the query architecture refactor. In clean CI, `start-solid-zaidan-example:test` and `start-solid-zaidan-example:typecheck` can import `@better-auth-ui/solid` through package exports before upstream package `dist` exists. This PR scopes the dependency ordering fix to the affected example targets only, avoiding a global test/typecheck runtime cost.

## Validation

- [x] `rm -rf packages/core/dist packages/solid/dist && bun nx run start-solid-zaidan-example:typecheck --skip-nx-cache`
- [x] `rm -rf packages/core/dist packages/solid/dist && bun nx run start-solid-zaidan-example:test --skip-nx-cache`
- [x] `bun nx run @better-auth-ui/solid:typecheck --skip-nx-cache`
- [x] `bun nx run @better-auth-ui/solid:test --skip-nx-cache`
- [x] `bun biome check examples/start-solid-zaidan-example/package.json examples/start-solid-zaidan-example/src/components/auth/settings/security/change-password.tsx`
- [x] `git diff --check`

## Out of scope

- Query factory/core architecture refactor.
- React/Solid server helper API changes.
- Docs/examples migration for one-line query helpers.
- Global Nx `test.dependsOn` / `typecheck.dependsOn` changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved password change form error handling by using a typed error object for the mutation flow, ensuring errors are reliably displayed and the password fields are cleared appropriately when failures occur.
## Chores
* Updated Nx configuration for the example project so `test` and `typecheck` run after `build` (including dependency builds) to improve task execution consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->