### PR TITLE
Fix email provider links

### DIFF
--- a/apps/docs/.cache/fumadocs-typescript/103197d6e522.json
+++ b/apps/docs/.cache/fumadocs-typescript/103197d6e522.json
@@ -1,0 +1,27 @@
+[
+  {
+    "id": "change-password.tsx-ChangePasswordSettingsProps",
+    "name": "ChangePasswordSettingsProps",
+    "description": "",
+    "entries": [
+      {
+        "name": "class",
+        "description": "",
+        "tags": [],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "confirmPassword",
+        "description": "",
+        "tags": [],
+        "type": "boolean",
+        "simplifiedType": "boolean",
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  }
+]

--- a/packages/core/src/lib/email-provider-links.ts
+++ b/packages/core/src/lib/email-provider-links.ts
@@ -1,4 +1,6 @@
-import emailProviderData from "@mikkelscheike/email-provider-links/providers/emailproviders.json"
+import emailProviderData from "@mikkelscheike/email-provider-links/providers/emailproviders.json" with {
+  type: "json"
+}
 
 type RawEmailProvider = {
   companyProvider: string

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -9,8 +9,12 @@ export default defineConfig({
       formats: ["es"]
     },
     rolldownOptions: {
-      // All bare module IDs (not starting with `.` or `/` or `C:\`)
-      external: /^[^./](?!:[/\\])/
+      // Externalize all bare module IDs (not starting with `.` or `/` or `C:\`),
+      // except `.json` data files which must be inlined: the published package
+      // ships raw JSON that Node ESM only loads with an explicit
+      // `with { type: "json" }` attribute, and the bundler strips that attribute
+      // when externalizing. Inlining keeps the output browser-safe too.
+      external: (id) => /^[^./](?!:[/\\])/.test(id) && !id.endsWith(".json")
     }
   }
 })


### PR DESCRIPTION
This pull request primarily addresses how JSON files are handled during bundling and updates type definitions for password change settings. The most significant change ensures that JSON files are inlined during the build process to maintain compatibility with both Node ESM and browser environments.

**Build configuration and module handling:**

* Updated the `rolldownOptions.external` configuration in `vite.config.ts` to inline `.json` files instead of externalizing them, ensuring published packages handle JSON imports correctly in Node ESM and browsers.
* Modified the import statement in `email-provider-links.ts` to use the `with { type: "json" }` attribute, aligning with the updated handling of JSON files.

**Type definitions:**

* Added a new type definition for `ChangePasswordSettingsProps`, including optional `class` and `confirmPassword` properties, in the generated TypeScript documentation cache.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated JSON module handling in the build configuration to ensure compatibility with modern JavaScript module systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->