### PR TITLE
fix(auth): resolve avatar and api key regressions

### DIFF
--- a/apps/docs/src/components/auth/api-key/create-api-key-dialog.tsx
+++ b/apps/docs/src/components/auth/api-key/create-api-key-dialog.tsx
@@ -56,6 +56,15 @@ export function CreateApiKeyDialog({
     onOpenChange(nextOpen)
   }
 
+  const handleNewKeyDialogOpenChange = (nextOpen: boolean) => {
+    setIsNewKeyDialogOpen(nextOpen)
+
+    if (!nextOpen) {
+      setKeyName(null)
+      setSecretKey(null)
+    }
+  }
+
   const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault()
 
@@ -135,7 +144,7 @@ export function CreateApiKeyDialog({
 
       <NewApiKeyDialog
         open={isNewKeyDialogOpen}
-        onOpenChange={setIsNewKeyDialogOpen}
+        onOpenChange={handleNewKeyDialogOpenChange}
         secretKey={secretKey}
         name={keyName}
       />

--- a/apps/docs/src/components/auth/api-key/new-api-key-dialog.tsx
+++ b/apps/docs/src/components/auth/api-key/new-api-key-dialog.tsx
@@ -5,16 +5,15 @@ import { Check, Copy, Key } from "lucide-react"
 import { useState } from "react"
 import { toast } from "sonner"
 
+import { Button } from "@/components/ui/button"
 import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogMedia,
-  AlertDialogTitle
-} from "@/components/ui/alert-dialog"
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from "@/components/ui/dialog"
 import {
   InputGroup,
   InputGroupAddon,
@@ -42,6 +41,14 @@ export function NewApiKeyDialog({
 
   const [copied, setCopied] = useState(false)
 
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      setCopied(false)
+    }
+
+    onOpenChange(nextOpen)
+  }
+
   const copySecretKey = async () => {
     if (!secretKey) return
 
@@ -55,19 +62,18 @@ export function NewApiKeyDialog({
   }
 
   return (
-    <AlertDialog open={open} onOpenChange={onOpenChange}>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogMedia>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle>
             <Key />
-          </AlertDialogMedia>
+            {apiKeyLocalization.newApiKey}
+          </DialogTitle>
 
-          <AlertDialogTitle>{apiKeyLocalization.newApiKey}</AlertDialogTitle>
-
-          <AlertDialogDescription>
+          <DialogDescription>
             {apiKeyLocalization.newApiKeyWarning}
-          </AlertDialogDescription>
-        </AlertDialogHeader>
+          </DialogDescription>
+        </DialogHeader>
 
         <div className="flex flex-col gap-2">
           <Label htmlFor="new-api-key-secret">
@@ -94,12 +100,12 @@ export function NewApiKeyDialog({
           </InputGroup>
         </div>
 
-        <AlertDialogFooter>
-          <AlertDialogAction>
+        <DialogFooter>
+          <Button type="button" onClick={() => handleOpenChange(false)}>
             {apiKeyLocalization.dismissNewKey}
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   )
 }

--- a/apps/docs/src/components/auth/settings/account/change-avatar.tsx
+++ b/apps/docs/src/components/auth/settings/account/change-avatar.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { fileToBase64 } from "@better-auth-ui/core"
+import { fileToAvatarDataUrl } from "@better-auth-ui/core"
 import { useAuth, useSession, useUpdateUser } from "@better-auth-ui/react"
 import { Trash2, Upload } from "lucide-react"
 import { type ChangeEvent, useRef, useState } from "react"
@@ -47,7 +47,7 @@ export function ChangeAvatar({ className }: ChangeAvatarProps) {
         (await avatar.resize?.(file, avatar.size, avatar.extension)) || file
 
       const image =
-        (await avatar.upload?.(resized)) || (await fileToBase64(resized))
+        (await avatar.upload?.(resized)) || (await fileToAvatarDataUrl(resized))
 
       updateUser(
         { image },

--- a/examples/next-shadcn-example/src/components/auth/api-key/create-api-key-dialog.tsx
+++ b/examples/next-shadcn-example/src/components/auth/api-key/create-api-key-dialog.tsx
@@ -56,6 +56,15 @@ export function CreateApiKeyDialog({
     onOpenChange(nextOpen)
   }
 
+  const handleNewKeyDialogOpenChange = (nextOpen: boolean) => {
+    setIsNewKeyDialogOpen(nextOpen)
+
+    if (!nextOpen) {
+      setKeyName(null)
+      setSecretKey(null)
+    }
+  }
+
   const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault()
 
@@ -135,7 +144,7 @@ export function CreateApiKeyDialog({
 
       <NewApiKeyDialog
         open={isNewKeyDialogOpen}
-        onOpenChange={setIsNewKeyDialogOpen}
+        onOpenChange={handleNewKeyDialogOpenChange}
         secretKey={secretKey}
         name={keyName}
       />

--- a/examples/next-shadcn-example/src/components/auth/api-key/new-api-key-dialog.tsx
+++ b/examples/next-shadcn-example/src/components/auth/api-key/new-api-key-dialog.tsx
@@ -5,16 +5,15 @@ import { Check, Copy, Key } from "lucide-react"
 import { useState } from "react"
 import { toast } from "sonner"
 
+import { Button } from "@/components/ui/button"
 import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogMedia,
-  AlertDialogTitle
-} from "@/components/ui/alert-dialog"
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from "@/components/ui/dialog"
 import {
   InputGroup,
   InputGroupAddon,
@@ -42,6 +41,14 @@ export function NewApiKeyDialog({
 
   const [copied, setCopied] = useState(false)
 
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      setCopied(false)
+    }
+
+    onOpenChange(nextOpen)
+  }
+
   const copySecretKey = async () => {
     if (!secretKey) return
 
@@ -55,19 +62,18 @@ export function NewApiKeyDialog({
   }
 
   return (
-    <AlertDialog open={open} onOpenChange={onOpenChange}>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogMedia>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle>
             <Key />
-          </AlertDialogMedia>
+            {apiKeyLocalization.newApiKey}
+          </DialogTitle>
 
-          <AlertDialogTitle>{apiKeyLocalization.newApiKey}</AlertDialogTitle>
-
-          <AlertDialogDescription>
+          <DialogDescription>
             {apiKeyLocalization.newApiKeyWarning}
-          </AlertDialogDescription>
-        </AlertDialogHeader>
+          </DialogDescription>
+        </DialogHeader>
 
         <div className="flex flex-col gap-2">
           <Label htmlFor="new-api-key-secret">
@@ -94,12 +100,12 @@ export function NewApiKeyDialog({
           </InputGroup>
         </div>
 
-        <AlertDialogFooter>
-          <AlertDialogAction>
+        <DialogFooter>
+          <Button type="button" onClick={() => handleOpenChange(false)}>
             {apiKeyLocalization.dismissNewKey}
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   )
 }

--- a/examples/next-shadcn-example/src/components/auth/settings/account/change-avatar.tsx
+++ b/examples/next-shadcn-example/src/components/auth/settings/account/change-avatar.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { fileToBase64 } from "@better-auth-ui/core"
+import { fileToAvatarDataUrl } from "@better-auth-ui/core"
 import { useAuth, useSession, useUpdateUser } from "@better-auth-ui/react"
 import { Trash2, Upload } from "lucide-react"
 import { type ChangeEvent, useRef, useState } from "react"
@@ -47,7 +47,7 @@ export function ChangeAvatar({ className }: ChangeAvatarProps) {
         (await avatar.resize?.(file, avatar.size, avatar.extension)) || file
 
       const image =
-        (await avatar.upload?.(resized)) || (await fileToBase64(resized))
+        (await avatar.upload?.(resized)) || (await fileToAvatarDataUrl(resized))
 
       updateUser(
         { image },

--- a/examples/start-shadcn-baseui-example/src/components/auth/api-key/create-api-key-dialog.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/api-key/create-api-key-dialog.tsx
@@ -56,6 +56,15 @@ export function CreateApiKeyDialog({
     onOpenChange(nextOpen)
   }
 
+  const handleNewKeyDialogOpenChange = (nextOpen: boolean) => {
+    setIsNewKeyDialogOpen(nextOpen)
+
+    if (!nextOpen) {
+      setKeyName(null)
+      setSecretKey(null)
+    }
+  }
+
   const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault()
 
@@ -135,7 +144,7 @@ export function CreateApiKeyDialog({
 
       <NewApiKeyDialog
         open={isNewKeyDialogOpen}
-        onOpenChange={setIsNewKeyDialogOpen}
+        onOpenChange={handleNewKeyDialogOpenChange}
         secretKey={secretKey}
         name={keyName}
       />

--- a/examples/start-shadcn-baseui-example/src/components/auth/api-key/new-api-key-dialog.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/api-key/new-api-key-dialog.tsx
@@ -5,16 +5,15 @@ import { Check, Copy, Key } from "lucide-react"
 import { useState } from "react"
 import { toast } from "sonner"
 
+import { Button } from "@/components/ui/button"
 import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogMedia,
-  AlertDialogTitle
-} from "@/components/ui/alert-dialog"
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from "@/components/ui/dialog"
 import {
   InputGroup,
   InputGroupAddon,
@@ -42,6 +41,14 @@ export function NewApiKeyDialog({
 
   const [copied, setCopied] = useState(false)
 
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      setCopied(false)
+    }
+
+    onOpenChange(nextOpen)
+  }
+
   const copySecretKey = async () => {
     if (!secretKey) return
 
@@ -55,19 +62,18 @@ export function NewApiKeyDialog({
   }
 
   return (
-    <AlertDialog open={open} onOpenChange={onOpenChange}>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogMedia>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle>
             <Key />
-          </AlertDialogMedia>
+            {apiKeyLocalization.newApiKey}
+          </DialogTitle>
 
-          <AlertDialogTitle>{apiKeyLocalization.newApiKey}</AlertDialogTitle>
-
-          <AlertDialogDescription>
+          <DialogDescription>
             {apiKeyLocalization.newApiKeyWarning}
-          </AlertDialogDescription>
-        </AlertDialogHeader>
+          </DialogDescription>
+        </DialogHeader>
 
         <div className="flex flex-col gap-2">
           <Label htmlFor="new-api-key-secret">
@@ -94,12 +100,12 @@ export function NewApiKeyDialog({
           </InputGroup>
         </div>
 
-        <AlertDialogFooter>
-          <AlertDialogAction>
+        <DialogFooter>
+          <Button type="button" onClick={() => handleOpenChange(false)}>
             {apiKeyLocalization.dismissNewKey}
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   )
 }

--- a/examples/start-shadcn-baseui-example/src/components/auth/settings/account/change-avatar.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/settings/account/change-avatar.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { fileToBase64 } from "@better-auth-ui/core"
+import { fileToAvatarDataUrl } from "@better-auth-ui/core"
 import { useAuth, useSession, useUpdateUser } from "@better-auth-ui/react"
 import { Trash2, Upload } from "lucide-react"
 import { type ChangeEvent, useRef, useState } from "react"
@@ -47,7 +47,7 @@ export function ChangeAvatar({ className }: ChangeAvatarProps) {
         (await avatar.resize?.(file, avatar.size, avatar.extension)) || file
 
       const image =
-        (await avatar.upload?.(resized)) || (await fileToBase64(resized))
+        (await avatar.upload?.(resized)) || (await fileToAvatarDataUrl(resized))
 
       updateUser(
         { image },

--- a/examples/start-shadcn-example/src/components/auth/api-key/create-api-key-dialog.tsx
+++ b/examples/start-shadcn-example/src/components/auth/api-key/create-api-key-dialog.tsx
@@ -56,6 +56,15 @@ export function CreateApiKeyDialog({
     onOpenChange(nextOpen)
   }
 
+  const handleNewKeyDialogOpenChange = (nextOpen: boolean) => {
+    setIsNewKeyDialogOpen(nextOpen)
+
+    if (!nextOpen) {
+      setKeyName(null)
+      setSecretKey(null)
+    }
+  }
+
   const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault()
 
@@ -135,7 +144,7 @@ export function CreateApiKeyDialog({
 
       <NewApiKeyDialog
         open={isNewKeyDialogOpen}
-        onOpenChange={setIsNewKeyDialogOpen}
+        onOpenChange={handleNewKeyDialogOpenChange}
         secretKey={secretKey}
         name={keyName}
       />

--- a/examples/start-shadcn-example/src/components/auth/api-key/new-api-key-dialog.tsx
+++ b/examples/start-shadcn-example/src/components/auth/api-key/new-api-key-dialog.tsx
@@ -5,16 +5,15 @@ import { Check, Copy, Key } from "lucide-react"
 import { useState } from "react"
 import { toast } from "sonner"
 
+import { Button } from "@/components/ui/button"
 import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogMedia,
-  AlertDialogTitle
-} from "@/components/ui/alert-dialog"
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from "@/components/ui/dialog"
 import {
   InputGroup,
   InputGroupAddon,
@@ -42,6 +41,14 @@ export function NewApiKeyDialog({
 
   const [copied, setCopied] = useState(false)
 
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      setCopied(false)
+    }
+
+    onOpenChange(nextOpen)
+  }
+
   const copySecretKey = async () => {
     if (!secretKey) return
 
@@ -55,19 +62,18 @@ export function NewApiKeyDialog({
   }
 
   return (
-    <AlertDialog open={open} onOpenChange={onOpenChange}>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogMedia>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle>
             <Key />
-          </AlertDialogMedia>
+            {apiKeyLocalization.newApiKey}
+          </DialogTitle>
 
-          <AlertDialogTitle>{apiKeyLocalization.newApiKey}</AlertDialogTitle>
-
-          <AlertDialogDescription>
+          <DialogDescription>
             {apiKeyLocalization.newApiKeyWarning}
-          </AlertDialogDescription>
-        </AlertDialogHeader>
+          </DialogDescription>
+        </DialogHeader>
 
         <div className="flex flex-col gap-2">
           <Label htmlFor="new-api-key-secret">
@@ -94,12 +100,12 @@ export function NewApiKeyDialog({
           </InputGroup>
         </div>
 
-        <AlertDialogFooter>
-          <AlertDialogAction>
+        <DialogFooter>
+          <Button type="button" onClick={() => handleOpenChange(false)}>
             {apiKeyLocalization.dismissNewKey}
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   )
 }

--- a/examples/start-shadcn-example/src/components/auth/settings/account/change-avatar.tsx
+++ b/examples/start-shadcn-example/src/components/auth/settings/account/change-avatar.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { fileToBase64 } from "@better-auth-ui/core"
+import { fileToAvatarDataUrl } from "@better-auth-ui/core"
 import { useAuth, useSession, useUpdateUser } from "@better-auth-ui/react"
 import { Trash2, Upload } from "lucide-react"
 import { type ChangeEvent, useRef, useState } from "react"
@@ -47,7 +47,7 @@ export function ChangeAvatar({ className }: ChangeAvatarProps) {
         (await avatar.resize?.(file, avatar.size, avatar.extension)) || file
 
       const image =
-        (await avatar.upload?.(resized)) || (await fileToBase64(resized))
+        (await avatar.upload?.(resized)) || (await fileToAvatarDataUrl(resized))
 
       updateUser(
         { image },

--- a/examples/start-solid-zaidan-example/src/components/auth/api-key/create-api-key-dialog.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/api-key/create-api-key-dialog.tsx
@@ -41,6 +41,15 @@ export function CreateApiKeyDialog(props: {
     }
   }))
 
+  const handleNewKeyDialogOpenChange = (open: boolean) => {
+    setIsNewKeyDialogOpen(open)
+
+    if (!open) {
+      setNewApiKeyName(null)
+      setNewApiKeySecret(null)
+    }
+  }
+
   const submitCreateApiKey = (event: SubmitEvent) => {
     event.preventDefault()
 
@@ -105,8 +114,15 @@ export function CreateApiKeyDialog(props: {
         </form>
       </DialogContent>
 
-      <Dialog open={isNewKeyDialogOpen()} onOpenChange={setIsNewKeyDialogOpen}>
-        <NewApiKeyDialog name={newApiKeyName()} secretKey={newApiKeySecret()} />
+      <Dialog
+        open={isNewKeyDialogOpen()}
+        onOpenChange={handleNewKeyDialogOpenChange}
+      >
+        <NewApiKeyDialog
+          name={newApiKeyName()}
+          onDismiss={() => handleNewKeyDialogOpenChange(false)}
+          secretKey={newApiKeySecret()}
+        />
       </Dialog>
     </>
   )

--- a/examples/start-solid-zaidan-example/src/components/auth/api-key/create-api-key-dialog.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/api-key/create-api-key-dialog.tsx
@@ -121,6 +121,7 @@ export function CreateApiKeyDialog(props: {
         <NewApiKeyDialog
           name={newApiKeyName()}
           onDismiss={() => handleNewKeyDialogOpenChange(false)}
+          open={isNewKeyDialogOpen()}
           secretKey={newApiKeySecret()}
         />
       </Dialog>

--- a/examples/start-solid-zaidan-example/src/components/auth/api-key/new-api-key-dialog.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/api-key/new-api-key-dialog.tsx
@@ -1,7 +1,7 @@
 import { apiKeyLocalization } from "@better-auth-ui/core/plugins"
 import { useAuth } from "@better-auth-ui/solid"
 import { Check, Copy, Key } from "lucide-solid"
-import { createSignal, Show } from "solid-js"
+import { createEffect, createSignal, Show } from "solid-js"
 import { toast } from "solid-sonner"
 import { Button } from "@/components/ui/button"
 import {
@@ -22,10 +22,22 @@ import {
 export function NewApiKeyDialog(props: {
   name: string | null
   onDismiss: () => void
+  open: boolean
   secretKey: string | null
 }) {
   const auth = useAuth()
   const [isCopied, setIsCopied] = createSignal(false)
+
+  createEffect(() => {
+    if (!props.open) {
+      setIsCopied(false)
+    }
+  })
+
+  const handleDismiss = () => {
+    setIsCopied(false)
+    props.onDismiss()
+  }
 
   const copySecretKey = async () => {
     if (!props.secretKey) return
@@ -79,7 +91,7 @@ export function NewApiKeyDialog(props: {
       </Field>
 
       <DialogFooter>
-        <Button onClick={props.onDismiss} type="button">
+        <Button onClick={handleDismiss} type="button">
           {apiKeyLocalization.dismissNewKey}
         </Button>
       </DialogFooter>

--- a/examples/start-solid-zaidan-example/src/components/auth/api-key/new-api-key-dialog.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/api-key/new-api-key-dialog.tsx
@@ -5,7 +5,6 @@ import { createSignal, Show } from "solid-js"
 import { toast } from "solid-sonner"
 import { Button } from "@/components/ui/button"
 import {
-  DialogClose,
   DialogContent,
   DialogDescription,
   DialogFooter,
@@ -22,6 +21,7 @@ import {
 
 export function NewApiKeyDialog(props: {
   name: string | null
+  onDismiss: () => void
   secretKey: string | null
 }) {
   const auth = useAuth()
@@ -40,7 +40,7 @@ export function NewApiKeyDialog(props: {
   }
 
   return (
-    <DialogContent>
+    <DialogContent showCloseButton={false}>
       <DialogHeader>
         <div class="flex size-10 items-center justify-center rounded-md bg-muted">
           <Key class="size-4.5" />
@@ -79,9 +79,9 @@ export function NewApiKeyDialog(props: {
       </Field>
 
       <DialogFooter>
-        <DialogClose as={Button}>
+        <Button onClick={props.onDismiss} type="button">
           {apiKeyLocalization.dismissNewKey}
-        </DialogClose>
+        </Button>
       </DialogFooter>
     </DialogContent>
   )

--- a/examples/start-solid-zaidan-example/src/components/auth/settings/account/change-avatar.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/settings/account/change-avatar.tsx
@@ -1,4 +1,4 @@
-import { fileToBase64 } from "@better-auth-ui/core"
+import { fileToAvatarDataUrl } from "@better-auth-ui/core"
 import { updateUserOptions, useAuth, useSession } from "@better-auth-ui/solid"
 import { createMutation } from "@tanstack/solid-query"
 import { Trash2, Upload } from "lucide-solid"
@@ -50,7 +50,8 @@ export function ChangeAvatar(props: ChangeAvatarProps) {
           auth.avatar.extension
         )) || file
       const image =
-        (await auth.avatar.upload?.(resized)) || (await fileToBase64(resized))
+        (await auth.avatar.upload?.(resized)) ||
+        (await fileToAvatarDataUrl(resized))
 
       updateUser.mutate(
         { image },

--- a/examples/start-solid-zaidan-example/tests/auth-route.test.ts
+++ b/examples/start-solid-zaidan-example/tests/auth-route.test.ts
@@ -1340,7 +1340,7 @@ describe("Solid auth route component selection", () => {
     )
     expect(userProfile).toContain("<ChangeAvatar")
     expect(userProfile).not.toContain("handleAvatarFileChange")
-    expect(changeAvatar).toContain("fileToBase64")
+    expect(changeAvatar).toContain("fileToAvatarDataUrl")
     expect(changeAvatar).toContain("updateUserOptions")
     expect(changeAvatar).toContain("avatarChangedSuccess")
     expect(providerButton).toContain("auth.authClient.signIn.social")
@@ -1957,7 +1957,7 @@ describe("Solid auth route component selection", () => {
       "utf8"
     )
 
-    expect(changeAvatar).toContain("fileToBase64")
+    expect(changeAvatar).toContain("fileToAvatarDataUrl")
     expect(changeAvatar).toContain('import { toast } from "solid-sonner"')
     expect(changeAvatar).toContain("DropdownMenu")
     expect(changeAvatar).toContain("DropdownMenuContent")

--- a/packages/core/src/config/avatar-config.ts
+++ b/packages/core/src/config/avatar-config.ts
@@ -33,7 +33,9 @@ export type AvatarConfig = {
   size: number
   /**
    * Upload a file and return the URL where it was stored.
-   * When undefined, the image is base64-encoded and saved directly to `user.image`.
+   * When undefined, a compact data URL is saved directly to `user.image`.
+   * The fallback is optimized for session cookie caches, while uploaded files
+   * keep the size and format produced by {@link resize}.
    */
   upload?: (file: File) => Promise<string>
 }

--- a/packages/core/src/lib/utils.ts
+++ b/packages/core/src/lib/utils.ts
@@ -1,5 +1,10 @@
 import type { DeepPartial } from "./deep-partial"
 
+const EMBEDDED_AVATAR_MAX_BYTES = 4_096
+const EMBEDDED_AVATAR_MAX_DIMENSION = 96
+const EMBEDDED_AVATAR_MIN_DIMENSION = 16
+const EMBEDDED_AVATAR_QUALITIES = [0.82, 0.68, 0.54, 0.4] as const
+
 /**
  * Type guard that checks whether a value is a non-null, non-array object.
  */
@@ -109,12 +114,123 @@ export function resizeAvatar(
  * @returns A promise that resolves to the base64 data URL.
  */
 export function fileToBase64(file: File): Promise<string> {
+  return blobToDataUrl(file)
+}
+
+function blobToDataUrl(blob: Blob): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader()
-    reader.onload = () => resolve(reader.result as string)
+    reader.onload = () => {
+      if (typeof reader.result === "string") {
+        resolve(reader.result)
+        return
+      }
+
+      reject(new Error("Failed to read file"))
+    }
     reader.onerror = () => reject(new Error("Failed to read file"))
-    reader.readAsDataURL(file)
+    reader.readAsDataURL(blob)
   })
+}
+
+function canvasToBlob(
+  canvas: HTMLCanvasElement,
+  type: string,
+  quality: number
+): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (blob) {
+          resolve(blob)
+          return
+        }
+
+        reject(new Error("Could not encode avatar"))
+      },
+      type,
+      quality
+    )
+  })
+}
+
+function embeddedAvatarDimensions(maxDimension: number) {
+  const dimensions: number[] = []
+  let dimension = maxDimension
+
+  while (dimension > EMBEDDED_AVATAR_MIN_DIMENSION) {
+    dimensions.push(dimension)
+    dimension = Math.floor(dimension * 0.75)
+  }
+
+  dimensions.push(Math.min(maxDimension, EMBEDDED_AVATAR_MIN_DIMENSION))
+
+  return dimensions
+}
+
+/**
+ * Convert an avatar to a compact data URL for the no-uploader fallback.
+ *
+ * Better Auth can cache the complete session user in a response cookie. Keeping
+ * embedded avatars below a conservative byte limit prevents the image from
+ * overflowing HTTP response headers while preserving higher-quality files for
+ * configured upload providers.
+ *
+ * @param file - The resized avatar file to encode.
+ * @returns A promise that resolves to a compact WebP data URL.
+ */
+export async function fileToAvatarDataUrl(file: File): Promise<string> {
+  const sourceUrl = URL.createObjectURL(file)
+  const image = new Image()
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      image.onload = () => resolve()
+      image.onerror = () => reject(new Error("Failed to load avatar"))
+      image.src = sourceUrl
+    })
+
+    const sourceSide = Math.min(image.naturalWidth, image.naturalHeight)
+    const maxDimension = Math.min(sourceSide, EMBEDDED_AVATAR_MAX_DIMENSION)
+    const cropX = (image.naturalWidth - sourceSide) / 2
+    const cropY = (image.naturalHeight - sourceSide) / 2
+    const canvas = document.createElement("canvas")
+    const context = canvas.getContext("2d")
+
+    if (!context) {
+      throw new Error("Could not get canvas context")
+    }
+
+    for (const dimension of embeddedAvatarDimensions(maxDimension)) {
+      canvas.width = dimension
+      canvas.height = dimension
+      context.clearRect(0, 0, dimension, dimension)
+      context.drawImage(
+        image,
+        cropX,
+        cropY,
+        sourceSide,
+        sourceSide,
+        0,
+        0,
+        dimension,
+        dimension
+      )
+
+      for (const quality of EMBEDDED_AVATAR_QUALITIES) {
+        const blob = await canvasToBlob(canvas, "image/webp", quality)
+        const dataUrl = await blobToDataUrl(blob)
+
+        if (dataUrl.length <= EMBEDDED_AVATAR_MAX_BYTES) {
+          return dataUrl
+        }
+      }
+    }
+
+    throw new Error("Could not reduce avatar to a safe embedded size")
+  } finally {
+    URL.revokeObjectURL(sourceUrl)
+  }
 }
 
 /**

--- a/packages/heroui/src/components/auth/api-key/create-api-key-dialog.tsx
+++ b/packages/heroui/src/components/auth/api-key/create-api-key-dialog.tsx
@@ -53,6 +53,15 @@ export function CreateApiKeyDialog({
     onOpenChange(open)
   }
 
+  const handleNewKeyDialogOpenChange = (open: boolean) => {
+    setIsNewKeyDialogOpen(open)
+
+    if (!open) {
+      setKeyName(null)
+      setSecretKey(null)
+    }
+  }
+
   const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault()
 
@@ -138,7 +147,7 @@ export function CreateApiKeyDialog({
 
       <NewApiKeyDialog
         isOpen={isNewKeyDialogOpen}
-        onOpenChange={setIsNewKeyDialogOpen}
+        onOpenChange={handleNewKeyDialogOpenChange}
         secretKey={secretKey}
         name={keyName}
       />

--- a/packages/heroui/src/components/auth/api-key/new-api-key-dialog.tsx
+++ b/packages/heroui/src/components/auth/api-key/new-api-key-dialog.tsx
@@ -1,10 +1,10 @@
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { Check, Copy, Key } from "@gravity-ui/icons"
 import {
-  AlertDialog,
   Button,
   InputGroup,
   Label,
+  Modal,
   TextField,
   toast
 } from "@heroui/react"
@@ -30,6 +30,14 @@ export function NewApiKeyDialog({
 
   const [copied, setCopied] = useState(false)
 
+  const handleOpenChange = (open: boolean) => {
+    if (!open) {
+      setCopied(false)
+    }
+
+    onOpenChange(open)
+  }
+
   const copySecretKey = async () => {
     if (!secretKey) return
 
@@ -43,22 +51,20 @@ export function NewApiKeyDialog({
   }
 
   return (
-    <AlertDialog.Backdrop isOpen={isOpen} onOpenChange={onOpenChange}>
-      <AlertDialog.Container>
-        <AlertDialog.Dialog>
-          <AlertDialog.CloseTrigger />
+    <Modal.Backdrop isOpen={isOpen} onOpenChange={handleOpenChange}>
+      <Modal.Container>
+        <Modal.Dialog>
+          <Modal.CloseTrigger />
 
-          <AlertDialog.Header>
-            <AlertDialog.Icon status="warning">
+          <Modal.Header>
+            <Modal.Icon className="bg-warning-soft text-warning-soft-foreground">
               <Key />
-            </AlertDialog.Icon>
+            </Modal.Icon>
 
-            <AlertDialog.Heading>
-              {apiKeyLocalization.newApiKey}
-            </AlertDialog.Heading>
-          </AlertDialog.Header>
+            <Modal.Heading>{apiKeyLocalization.newApiKey}</Modal.Heading>
+          </Modal.Header>
 
-          <AlertDialog.Body className="flex flex-col gap-4 overflow-visible">
+          <Modal.Body className="flex flex-col gap-4 overflow-visible">
             <p className="text-muted text-sm">
               {apiKeyLocalization.newApiKeyWarning}
             </p>
@@ -82,13 +88,15 @@ export function NewApiKeyDialog({
                 </InputGroup.Suffix>
               </InputGroup>
             </TextField>
-          </AlertDialog.Body>
+          </Modal.Body>
 
-          <AlertDialog.Footer>
-            <Button slot="close">{apiKeyLocalization.dismissNewKey}</Button>
-          </AlertDialog.Footer>
-        </AlertDialog.Dialog>
-      </AlertDialog.Container>
-    </AlertDialog.Backdrop>
+          <Modal.Footer>
+            <Button onPress={() => handleOpenChange(false)}>
+              {apiKeyLocalization.dismissNewKey}
+            </Button>
+          </Modal.Footer>
+        </Modal.Dialog>
+      </Modal.Container>
+    </Modal.Backdrop>
   )
 }

--- a/packages/heroui/src/components/auth/settings/account/change-avatar.tsx
+++ b/packages/heroui/src/components/auth/settings/account/change-avatar.tsx
@@ -1,4 +1,4 @@
-import { fileToBase64 } from "@better-auth-ui/core"
+import { fileToAvatarDataUrl } from "@better-auth-ui/core"
 import { useAuth, useSession, useUpdateUser } from "@better-auth-ui/react"
 import { CloudArrowUpIn, TrashBin } from "@gravity-ui/icons"
 import { Button, cn, Dropdown, Label, Spinner, toast } from "@heroui/react"
@@ -36,7 +36,7 @@ export function ChangeAvatar({ className }: ChangeAvatarProps) {
         (await avatar.resize?.(file, avatar.size, avatar.extension)) || file
 
       const image =
-        (await avatar.upload?.(resized)) || (await fileToBase64(resized))
+        (await avatar.upload?.(resized)) || (await fileToAvatarDataUrl(resized))
 
       updateUser(
         { image },

--- a/packages/heroui/tests/api-key.test.tsx
+++ b/packages/heroui/tests/api-key.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { useState } from "react"
+import { describe, expect, it } from "vitest"
+import { NewApiKeyDialog } from "../src/components/auth/api-key/new-api-key-dialog"
+import { AuthProvider } from "../src/components/auth/auth-provider"
+import { apiKeyPlugin } from "../src/lib/auth/api-key-plugin"
+
+function createMockAuthClient() {
+  return {
+    useSession: () => ({ data: null, isPending: false, error: null })
+  } as unknown as Parameters<typeof AuthProvider>[0]["authClient"]
+}
+
+function ControlledNewApiKeyDialog() {
+  const [isOpen, setIsOpen] = useState(true)
+
+  return (
+    <NewApiKeyDialog
+      isOpen={isOpen}
+      name="Deploy key"
+      onOpenChange={setIsOpen}
+      secretKey="api-key-secret"
+    />
+  )
+}
+
+describe("<NewApiKeyDialog />", () => {
+  it("dismisses the controlled dialog after the key is saved", async () => {
+    const user = userEvent.setup()
+
+    render(
+      <AuthProvider
+        authClient={createMockAuthClient()}
+        navigate={() => {}}
+        plugins={[apiKeyPlugin()]}
+      >
+        <ControlledNewApiKeyDialog />
+      </AuthProvider>
+    )
+
+    await user.click(screen.getByRole("button", { name: /i've saved my key/i }))
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    })
+  })
+})

--- a/packages/react/tests/lib/avatar-data-url.test.ts
+++ b/packages/react/tests/lib/avatar-data-url.test.ts
@@ -1,0 +1,59 @@
+import { fileToAvatarDataUrl } from "@better-auth-ui/core"
+import { describe, expect, it } from "vitest"
+
+function canvasToPngFile(canvas: HTMLCanvasElement): Promise<File> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (!blob) {
+        reject(new Error("Could not create test avatar"))
+        return
+      }
+
+      resolve(new File([blob], "avatar.png", { type: blob.type }))
+    }, "image/png")
+  })
+}
+
+async function createLargeAvatar() {
+  const canvas = document.createElement("canvas")
+  canvas.width = 256
+  canvas.height = 256
+
+  const context = canvas.getContext("2d")
+  if (!context) {
+    throw new Error("Could not get canvas context")
+  }
+
+  const imageData = context.createImageData(canvas.width, canvas.height)
+  let value = 17
+
+  for (let offset = 0; offset < imageData.data.length; offset += 4) {
+    value = (value * 75 + 74) % 65_537
+    imageData.data[offset] = value % 256
+    imageData.data[offset + 1] = (value >> 4) % 256
+    imageData.data[offset + 2] = (value >> 8) % 256
+    imageData.data[offset + 3] = 255
+  }
+
+  context.putImageData(imageData, 0, 0)
+
+  return canvasToPngFile(canvas)
+}
+
+describe("fileToAvatarDataUrl", () => {
+  it("keeps embedded avatars within the response-header budget", async () => {
+    const source = await createLargeAvatar()
+    expect(source.size).toBeGreaterThan(4_096)
+
+    const dataUrl = await fileToAvatarDataUrl(source)
+    const optimized = await fetch(dataUrl).then((response) => response.blob())
+    const image = await createImageBitmap(optimized)
+
+    expect(dataUrl.length).toBeLessThanOrEqual(4_096)
+    expect(optimized.type).toBe("image/webp")
+    expect(image.width).toBeLessThanOrEqual(96)
+    expect(image.height).toBe(image.width)
+
+    image.close()
+  })
+})


### PR DESCRIPTION
## Summary

- keep no-uploader avatar data URLs within a 4 KB encoded budget before saving them to `user.image`
- make the one-time API key dialog dismiss through explicit controlled state and clear the secret after close
- apply both fixes across shadcn Radix, shadcn Base UI, HeroUI, Solid/Zaidan, docs, and synced examples
- add focused regression coverage for avatar encoding and API key dismissal

## Root cause

The avatar fallback introduced with avatar support resized images to 256 px PNGs, then stored the full base64 data URL in `user.image`. Better Auth session cookie caching serializes the user into response cookies, so refreshing the session after an avatar update could produce enough `Set-Cookie` data for Node to reject the response with `Parse Error: Header overflow`. The fallback now creates a compact square WebP and iterates dimensions and quality until the complete encoded data URL is at most 4 KB. Configured upload providers still receive the normal resized file.

The API key result dialog relied on alert-dialog primitive close behavior. In the Base UI shadcn implementation, `AlertDialogAction` is a styled button rather than a close primitive, so it never notified the controlled owner with `open=false`. The shared consumer also depended on implementation-specific behavior in the other UI kits. The result is now a regular non-destructive dialog or modal with an explicit controlled dismiss callback, and the one-time secret and name are cleared whenever it closes.

## Validation

- `bunx biome check .`
- `bun nx affected -t test typecheck lint --base=main --parallel=3`
- `bun nx run start-shadcn-example:registry:build`
- `bun nx run start-solid-zaidan-example:registry:build`

Closes #461
Closes #462

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added compact, optimized avatar fallback generation (embedded WebP data URLs) when no upload service is configured.
  - API key creation dialogs now use consistent modal dismissal behavior across implementations.
- **Bug Fixes**
  - Closing API key dialogs now properly resets sensitive fields and clears “copied” state.
- **Documentation**
  - Clarified avatar fallback storage/optimization behavior in configuration docs.
- **Tests**
  - Added tests for API key dialog dismissal and avatar data URL output; updated avatar upload/delete assertions for the new fallback format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->