### PR TITLE
feat(api-key): add configurable expiration options

### DIFF
--- a/apps/docs/content/docs/heroui/plugins/api-key.mdx
+++ b/apps/docs/content/docs/heroui/plugins/api-key.mdx
@@ -5,7 +5,7 @@ description: Add programmatic API key management with create, copy, and revoke f
 
 import { Step, Steps } from 'fumadocs-ui/components/steps'
 
-The API key plugin adds programmatic API key management to your authentication UI. Users can create, copy, and revoke API keys from a security card in account settings.
+The API key plugin adds programmatic API key management to your authentication UI. Users can create, copy, and revoke API keys from a security card in account settings. New keys can use a configurable expiration interval, and each listed key shows when it expires.
 
 It contributes:
 
@@ -71,6 +71,42 @@ import { authClient } from "@/lib/auth-client"
 
 </Step>
 </Steps>
+
+## Configure expiration
+
+The create dialog offers 30 days, 90 days, and Never by default. It initially selects 30 days. Configure the choices through `apiKeyPlugin()`:
+
+```tsx title="components/providers.tsx"
+apiKeyPlugin({
+  keyExpiration: {
+    intervals: [7, 30, 90],
+    defaultInterval: 30,
+    allowNever: true
+  }
+})
+```
+
+`intervals` and `defaultInterval` use days. Better Auth receives the selected lifetime as seconds.
+
+Keep the UI choices within the limits in your Better Auth server configuration:
+
+```ts title="lib/auth.ts"
+apiKey({
+  keyExpiration: {
+    minExpiresIn: 7,
+    maxExpiresIn: 90,
+    defaultExpiresIn: null
+  }
+})
+```
+
+When `allowNever` is enabled, selecting Never sends no custom interval. Better Auth will still apply `defaultExpiresIn` if the server defines one, so set `allowNever: false` in the UI when your server always requires expiration.
+
+To remove the expiration field and rely entirely on the server default:
+
+```tsx title="components/providers.tsx"
+apiKeyPlugin({ keyExpiration: false })
+```
 
 ## Components
 

--- a/apps/docs/content/docs/shadcn/plugins/api-key.mdx
+++ b/apps/docs/content/docs/shadcn/plugins/api-key.mdx
@@ -5,7 +5,7 @@ description: Add programmatic API key management with create, copy, and revoke f
 
 import { Step, Steps } from 'fumadocs-ui/components/steps'
 
-The API key plugin adds programmatic API key management to your authentication UI. Users can create, copy, and revoke API keys from a security card in account settings.
+The API key plugin adds programmatic API key management to your authentication UI. Users can create, copy, and revoke API keys from a security card in account settings. New keys can use a configurable expiration interval, and each listed key shows when it expires.
 
 It contributes:
 
@@ -94,6 +94,42 @@ import { authClient } from "@/lib/auth-client"
 
 </Step>
 </Steps>
+
+## Configure expiration
+
+The create dialog offers 30 days, 90 days, and Never by default. It initially selects 30 days. Configure the choices through `apiKeyPlugin()`:
+
+```tsx title="components/providers.tsx"
+apiKeyPlugin({
+  keyExpiration: {
+    intervals: [7, 30, 90],
+    defaultInterval: 30,
+    allowNever: true
+  }
+})
+```
+
+`intervals` and `defaultInterval` use days. Better Auth receives the selected lifetime as seconds.
+
+Keep the UI choices within the limits in your Better Auth server configuration:
+
+```ts title="lib/auth.ts"
+apiKey({
+  keyExpiration: {
+    minExpiresIn: 7,
+    maxExpiresIn: 90,
+    defaultExpiresIn: null
+  }
+})
+```
+
+When `allowNever` is enabled, selecting Never sends no custom interval. Better Auth will still apply `defaultExpiresIn` if the server defines one, so set `allowNever: false` in the UI when your server always requires expiration.
+
+To remove the expiration field and rely entirely on the server default:
+
+```tsx title="components/providers.tsx"
+apiKeyPlugin({ keyExpiration: false })
+```
 
 ## Components
 

--- a/apps/docs/content/docs/zaidan/plugins/api-key.mdx
+++ b/apps/docs/content/docs/zaidan/plugins/api-key.mdx
@@ -5,7 +5,7 @@ description: Install Solid/Zaidan API key management with create, copy, and revo
 
 import { Step, Steps } from 'fumadocs-ui/components/steps'
 
-The API key plugin adds programmatic API key management to your Solid/Zaidan authentication settings. Users can create, reveal once, copy, list, and revoke API keys from security and organization settings.
+The API key plugin adds programmatic API key management to your Solid/Zaidan authentication settings. Users can create, reveal once, copy, list, and revoke API keys from security and organization settings. New keys can use a configurable expiration interval, and each listed key shows when it expires.
 
 It contributes:
 
@@ -94,6 +94,42 @@ import { apiKeyPlugin } from "@/lib/auth/api-key-plugin" // [!code highlight]
 
 </Step>
 </Steps>
+
+## Configure expiration
+
+The create dialog offers 30 days, 90 days, and Never by default. It initially selects 30 days. Configure the choices through the copied `apiKeyPlugin()`:
+
+```tsx title="src/components/providers.tsx"
+apiKeyPlugin({
+  keyExpiration: {
+    intervals: [7, 30, 90],
+    defaultInterval: 30,
+    allowNever: true
+  }
+})
+```
+
+`intervals` and `defaultInterval` use days. Better Auth receives the selected lifetime as seconds.
+
+Keep the UI choices within the limits in your Better Auth server configuration:
+
+```ts title="src/lib/auth.ts"
+apiKey({
+  keyExpiration: {
+    minExpiresIn: 7,
+    maxExpiresIn: 90,
+    defaultExpiresIn: null
+  }
+})
+```
+
+When `allowNever` is enabled, selecting Never sends no custom interval. Better Auth will still apply `defaultExpiresIn` if the server defines one, so set `allowNever: false` in the UI when your server always requires expiration.
+
+To remove the expiration field and rely entirely on the server default:
+
+```tsx title="src/components/providers.tsx"
+apiKeyPlugin({ keyExpiration: false })
+```
 
 ## Components
 

--- a/apps/docs/src/components/auth/api-key/api-key.tsx
+++ b/apps/docs/src/components/auth/api-key/api-key.tsx
@@ -44,10 +44,21 @@ export function ApiKey({ apiKey, hideDelete, organizationId }: ApiKeyProps) {
         <ItemTitle>{apiKey.name || apiKeyLocalization.apiKey}</ItemTitle>
         <ItemDescription className="font-mono">{preview}</ItemDescription>
         <ItemDescription>
+          {apiKeyLocalization.created}{" "}
           {new Date(apiKey.createdAt).toLocaleString(undefined, {
             dateStyle: "medium",
             timeStyle: "short"
           })}
+        </ItemDescription>
+        <ItemDescription>
+          {apiKey.expiresAt
+            ? `${apiKeyLocalization.expires} ${new Date(
+                apiKey.expiresAt
+              ).toLocaleString(undefined, {
+                dateStyle: "medium",
+                timeStyle: "short"
+              })}`
+            : apiKeyLocalization.neverExpires}
         </ItemDescription>
       </ItemContent>
       <ItemActions>

--- a/apps/docs/src/components/auth/api-key/create-api-key-dialog.tsx
+++ b/apps/docs/src/components/auth/api-key/create-api-key-dialog.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { apiKeyExpirationDaysToSeconds } from "@better-auth-ui/core/plugins"
 import {
   type ApiKeyAuthClient,
   useAuth,
@@ -18,8 +19,21 @@ import {
   DialogHeader,
   DialogTitle
 } from "@/components/ui/dialog"
-import { Field, FieldError, FieldLabel } from "@/components/ui/field"
+import {
+  Field,
+  FieldError,
+  FieldGroup,
+  FieldLabel
+} from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select"
 import { Spinner } from "@/components/ui/spinner"
 import { apiKeyPlugin } from "@/lib/auth/api-key-plugin"
 import { NewApiKeyDialog } from "./new-api-key-dialog"
@@ -37,7 +51,8 @@ export function CreateApiKeyDialog({
   organizationId
 }: CreateApiKeyDialogProps) {
   const { authClient, localization } = useAuth()
-  const { localization: apiKeyLocalization } = useAuthPlugin(apiKeyPlugin)
+  const { keyExpiration, localization: apiKeyLocalization } =
+    useAuthPlugin(apiKeyPlugin)
 
   const { mutate: createApiKey, isPending: isCreating } = useCreateApiKey(
     authClient as ApiKeyAuthClient
@@ -70,18 +85,22 @@ export function CreateApiKeyDialog({
 
     const formData = new FormData(e.target as HTMLFormElement)
     const name = (formData.get("name") as string).trim()
-
-    const payload =
-      name || organizationId
-        ? {
-            ...(name ? { name } : {}),
-            ...(organizationId
-              ? { organizationId, configId: "organization" }
-              : {})
-          }
+    const expiration = formData.get("expiration")
+    const expirationDays =
+      typeof expiration === "string" && expiration !== "never"
+        ? Number(expiration)
         : undefined
+    const expiresIn = expirationDays
+      ? apiKeyExpirationDaysToSeconds(expirationDays)
+      : undefined
 
-    createApiKey(payload, {
+    const payload = {
+      ...(name ? { name } : {}),
+      ...(expiresIn ? { expiresIn } : {}),
+      ...(organizationId ? { organizationId, configId: "organization" } : {})
+    }
+
+    createApiKey(Object.keys(payload).length > 0 ? payload : undefined, {
       onSuccess: (result) => {
         handleOpenChange(false)
         setKeyName(name)
@@ -107,21 +126,64 @@ export function CreateApiKeyDialog({
               </DialogDescription>
             </DialogHeader>
 
-            <Field>
-              <FieldLabel htmlFor="api-key-name">
-                {apiKeyLocalization.name}
-              </FieldLabel>
+            <FieldGroup>
+              <Field>
+                <FieldLabel htmlFor="api-key-name">
+                  {apiKeyLocalization.name}
+                </FieldLabel>
 
-              <Input
-                id="api-key-name"
-                name="name"
-                autoFocus
-                placeholder={localization.settings.optional}
-                disabled={isCreating}
-              />
+                <Input
+                  id="api-key-name"
+                  name="name"
+                  autoFocus
+                  placeholder={localization.settings.optional}
+                  disabled={isCreating}
+                />
 
-              <FieldError />
-            </Field>
+                <FieldError />
+              </Field>
+
+              {keyExpiration ? (
+                <Field>
+                  <FieldLabel htmlFor="api-key-expiration">
+                    {apiKeyLocalization.expiration}
+                  </FieldLabel>
+
+                  <Select
+                    name="expiration"
+                    defaultValue={
+                      keyExpiration.defaultInterval === null
+                        ? "never"
+                        : String(keyExpiration.defaultInterval)
+                    }
+                    disabled={isCreating}
+                  >
+                    <SelectTrigger id="api-key-expiration" className="w-full">
+                      <SelectValue />
+                    </SelectTrigger>
+
+                    <SelectContent>
+                      <SelectGroup>
+                        {keyExpiration.intervals.map((days) => (
+                          <SelectItem key={days} value={String(days)}>
+                            {days.toLocaleString()}{" "}
+                            {days === 1
+                              ? apiKeyLocalization.day
+                              : apiKeyLocalization.days}
+                          </SelectItem>
+                        ))}
+
+                        {keyExpiration.allowNever ? (
+                          <SelectItem value="never">
+                            {apiKeyLocalization.never}
+                          </SelectItem>
+                        ) : null}
+                      </SelectGroup>
+                    </SelectContent>
+                  </Select>
+                </Field>
+              ) : null}
+            </FieldGroup>
 
             <DialogFooter>
               <DialogClose

--- a/apps/docs/src/lib/auth-client.tsx
+++ b/apps/docs/src/lib/auth-client.tsx
@@ -186,7 +186,7 @@ const customFetchImpl: typeof fetch = async (input, _init) => {
             requestCount: 0,
             remaining: null,
             lastRequest: null,
-            expiresAt: null,
+            expiresAt: new Date(now + 86_400_000 * 30).toISOString(),
             createdAt: new Date(now - 86_400_000 * 7).toISOString(),
             updatedAt: new Date(now - 86_400_000 * 7).toISOString(),
             permissions: null,

--- a/examples/next-shadcn-example/src/components/auth/api-key/api-key.tsx
+++ b/examples/next-shadcn-example/src/components/auth/api-key/api-key.tsx
@@ -44,10 +44,21 @@ export function ApiKey({ apiKey, hideDelete, organizationId }: ApiKeyProps) {
         <ItemTitle>{apiKey.name || apiKeyLocalization.apiKey}</ItemTitle>
         <ItemDescription className="font-mono">{preview}</ItemDescription>
         <ItemDescription>
+          {apiKeyLocalization.created}{" "}
           {new Date(apiKey.createdAt).toLocaleString(undefined, {
             dateStyle: "medium",
             timeStyle: "short"
           })}
+        </ItemDescription>
+        <ItemDescription>
+          {apiKey.expiresAt
+            ? `${apiKeyLocalization.expires} ${new Date(
+                apiKey.expiresAt
+              ).toLocaleString(undefined, {
+                dateStyle: "medium",
+                timeStyle: "short"
+              })}`
+            : apiKeyLocalization.neverExpires}
         </ItemDescription>
       </ItemContent>
       <ItemActions>

--- a/examples/next-shadcn-example/src/components/auth/api-key/create-api-key-dialog.tsx
+++ b/examples/next-shadcn-example/src/components/auth/api-key/create-api-key-dialog.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { apiKeyExpirationDaysToSeconds } from "@better-auth-ui/core/plugins"
 import {
   type ApiKeyAuthClient,
   useAuth,
@@ -18,8 +19,21 @@ import {
   DialogHeader,
   DialogTitle
 } from "@/components/ui/dialog"
-import { Field, FieldError, FieldLabel } from "@/components/ui/field"
+import {
+  Field,
+  FieldError,
+  FieldGroup,
+  FieldLabel
+} from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select"
 import { Spinner } from "@/components/ui/spinner"
 import { apiKeyPlugin } from "@/lib/auth/api-key-plugin"
 import { NewApiKeyDialog } from "./new-api-key-dialog"
@@ -37,7 +51,8 @@ export function CreateApiKeyDialog({
   organizationId
 }: CreateApiKeyDialogProps) {
   const { authClient, localization } = useAuth()
-  const { localization: apiKeyLocalization } = useAuthPlugin(apiKeyPlugin)
+  const { keyExpiration, localization: apiKeyLocalization } =
+    useAuthPlugin(apiKeyPlugin)
 
   const { mutate: createApiKey, isPending: isCreating } = useCreateApiKey(
     authClient as ApiKeyAuthClient
@@ -70,18 +85,22 @@ export function CreateApiKeyDialog({
 
     const formData = new FormData(e.target as HTMLFormElement)
     const name = (formData.get("name") as string).trim()
-
-    const payload =
-      name || organizationId
-        ? {
-            ...(name ? { name } : {}),
-            ...(organizationId
-              ? { organizationId, configId: "organization" }
-              : {})
-          }
+    const expiration = formData.get("expiration")
+    const expirationDays =
+      typeof expiration === "string" && expiration !== "never"
+        ? Number(expiration)
         : undefined
+    const expiresIn = expirationDays
+      ? apiKeyExpirationDaysToSeconds(expirationDays)
+      : undefined
 
-    createApiKey(payload, {
+    const payload = {
+      ...(name ? { name } : {}),
+      ...(expiresIn ? { expiresIn } : {}),
+      ...(organizationId ? { organizationId, configId: "organization" } : {})
+    }
+
+    createApiKey(Object.keys(payload).length > 0 ? payload : undefined, {
       onSuccess: (result) => {
         handleOpenChange(false)
         setKeyName(name)
@@ -107,21 +126,64 @@ export function CreateApiKeyDialog({
               </DialogDescription>
             </DialogHeader>
 
-            <Field>
-              <FieldLabel htmlFor="api-key-name">
-                {apiKeyLocalization.name}
-              </FieldLabel>
+            <FieldGroup>
+              <Field>
+                <FieldLabel htmlFor="api-key-name">
+                  {apiKeyLocalization.name}
+                </FieldLabel>
 
-              <Input
-                id="api-key-name"
-                name="name"
-                autoFocus
-                placeholder={localization.settings.optional}
-                disabled={isCreating}
-              />
+                <Input
+                  id="api-key-name"
+                  name="name"
+                  autoFocus
+                  placeholder={localization.settings.optional}
+                  disabled={isCreating}
+                />
 
-              <FieldError />
-            </Field>
+                <FieldError />
+              </Field>
+
+              {keyExpiration ? (
+                <Field>
+                  <FieldLabel htmlFor="api-key-expiration">
+                    {apiKeyLocalization.expiration}
+                  </FieldLabel>
+
+                  <Select
+                    name="expiration"
+                    defaultValue={
+                      keyExpiration.defaultInterval === null
+                        ? "never"
+                        : String(keyExpiration.defaultInterval)
+                    }
+                    disabled={isCreating}
+                  >
+                    <SelectTrigger id="api-key-expiration" className="w-full">
+                      <SelectValue />
+                    </SelectTrigger>
+
+                    <SelectContent>
+                      <SelectGroup>
+                        {keyExpiration.intervals.map((days) => (
+                          <SelectItem key={days} value={String(days)}>
+                            {days.toLocaleString()}{" "}
+                            {days === 1
+                              ? apiKeyLocalization.day
+                              : apiKeyLocalization.days}
+                          </SelectItem>
+                        ))}
+
+                        {keyExpiration.allowNever ? (
+                          <SelectItem value="never">
+                            {apiKeyLocalization.never}
+                          </SelectItem>
+                        ) : null}
+                      </SelectGroup>
+                    </SelectContent>
+                  </Select>
+                </Field>
+              ) : null}
+            </FieldGroup>
 
             <DialogFooter>
               <DialogClose

--- a/examples/start-shadcn-baseui-example/src/components/auth/api-key/api-key.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/api-key/api-key.tsx
@@ -44,10 +44,21 @@ export function ApiKey({ apiKey, hideDelete, organizationId }: ApiKeyProps) {
         <ItemTitle>{apiKey.name || apiKeyLocalization.apiKey}</ItemTitle>
         <ItemDescription className="font-mono">{preview}</ItemDescription>
         <ItemDescription>
+          {apiKeyLocalization.created}{" "}
           {new Date(apiKey.createdAt).toLocaleString(undefined, {
             dateStyle: "medium",
             timeStyle: "short"
           })}
+        </ItemDescription>
+        <ItemDescription>
+          {apiKey.expiresAt
+            ? `${apiKeyLocalization.expires} ${new Date(
+                apiKey.expiresAt
+              ).toLocaleString(undefined, {
+                dateStyle: "medium",
+                timeStyle: "short"
+              })}`
+            : apiKeyLocalization.neverExpires}
         </ItemDescription>
       </ItemContent>
       <ItemActions>

--- a/examples/start-shadcn-baseui-example/src/components/auth/api-key/create-api-key-dialog.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/api-key/create-api-key-dialog.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { apiKeyExpirationDaysToSeconds } from "@better-auth-ui/core/plugins"
 import {
   type ApiKeyAuthClient,
   useAuth,
@@ -18,8 +19,21 @@ import {
   DialogHeader,
   DialogTitle
 } from "@/components/ui/dialog"
-import { Field, FieldError, FieldLabel } from "@/components/ui/field"
+import {
+  Field,
+  FieldError,
+  FieldGroup,
+  FieldLabel
+} from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select"
 import { Spinner } from "@/components/ui/spinner"
 import { apiKeyPlugin } from "@/lib/auth/api-key-plugin"
 import { NewApiKeyDialog } from "./new-api-key-dialog"
@@ -37,7 +51,8 @@ export function CreateApiKeyDialog({
   organizationId
 }: CreateApiKeyDialogProps) {
   const { authClient, localization } = useAuth()
-  const { localization: apiKeyLocalization } = useAuthPlugin(apiKeyPlugin)
+  const { keyExpiration, localization: apiKeyLocalization } =
+    useAuthPlugin(apiKeyPlugin)
 
   const { mutate: createApiKey, isPending: isCreating } = useCreateApiKey(
     authClient as ApiKeyAuthClient
@@ -70,18 +85,22 @@ export function CreateApiKeyDialog({
 
     const formData = new FormData(e.target as HTMLFormElement)
     const name = (formData.get("name") as string).trim()
-
-    const payload =
-      name || organizationId
-        ? {
-            ...(name ? { name } : {}),
-            ...(organizationId
-              ? { organizationId, configId: "organization" }
-              : {})
-          }
+    const expiration = formData.get("expiration")
+    const expirationDays =
+      typeof expiration === "string" && expiration !== "never"
+        ? Number(expiration)
         : undefined
+    const expiresIn = expirationDays
+      ? apiKeyExpirationDaysToSeconds(expirationDays)
+      : undefined
 
-    createApiKey(payload, {
+    const payload = {
+      ...(name ? { name } : {}),
+      ...(expiresIn ? { expiresIn } : {}),
+      ...(organizationId ? { organizationId, configId: "organization" } : {})
+    }
+
+    createApiKey(Object.keys(payload).length > 0 ? payload : undefined, {
       onSuccess: (result) => {
         handleOpenChange(false)
         setKeyName(name)
@@ -107,21 +126,64 @@ export function CreateApiKeyDialog({
               </DialogDescription>
             </DialogHeader>
 
-            <Field>
-              <FieldLabel htmlFor="api-key-name">
-                {apiKeyLocalization.name}
-              </FieldLabel>
+            <FieldGroup>
+              <Field>
+                <FieldLabel htmlFor="api-key-name">
+                  {apiKeyLocalization.name}
+                </FieldLabel>
 
-              <Input
-                id="api-key-name"
-                name="name"
-                autoFocus
-                placeholder={localization.settings.optional}
-                disabled={isCreating}
-              />
+                <Input
+                  id="api-key-name"
+                  name="name"
+                  autoFocus
+                  placeholder={localization.settings.optional}
+                  disabled={isCreating}
+                />
 
-              <FieldError />
-            </Field>
+                <FieldError />
+              </Field>
+
+              {keyExpiration ? (
+                <Field>
+                  <FieldLabel htmlFor="api-key-expiration">
+                    {apiKeyLocalization.expiration}
+                  </FieldLabel>
+
+                  <Select
+                    name="expiration"
+                    defaultValue={
+                      keyExpiration.defaultInterval === null
+                        ? "never"
+                        : String(keyExpiration.defaultInterval)
+                    }
+                    disabled={isCreating}
+                  >
+                    <SelectTrigger id="api-key-expiration" className="w-full">
+                      <SelectValue />
+                    </SelectTrigger>
+
+                    <SelectContent>
+                      <SelectGroup>
+                        {keyExpiration.intervals.map((days) => (
+                          <SelectItem key={days} value={String(days)}>
+                            {days.toLocaleString()}{" "}
+                            {days === 1
+                              ? apiKeyLocalization.day
+                              : apiKeyLocalization.days}
+                          </SelectItem>
+                        ))}
+
+                        {keyExpiration.allowNever ? (
+                          <SelectItem value="never">
+                            {apiKeyLocalization.never}
+                          </SelectItem>
+                        ) : null}
+                      </SelectGroup>
+                    </SelectContent>
+                  </Select>
+                </Field>
+              ) : null}
+            </FieldGroup>
 
             <DialogFooter>
               <DialogClose

--- a/examples/start-shadcn-example/registry.json
+++ b/examples/start-shadcn-example/registry.json
@@ -741,6 +741,7 @@
         "input-group",
         "item",
         "label",
+        "select",
         "separator",
         "skeleton",
         "sonner",

--- a/examples/start-shadcn-example/src/components/auth/api-key/api-key.tsx
+++ b/examples/start-shadcn-example/src/components/auth/api-key/api-key.tsx
@@ -44,10 +44,21 @@ export function ApiKey({ apiKey, hideDelete, organizationId }: ApiKeyProps) {
         <ItemTitle>{apiKey.name || apiKeyLocalization.apiKey}</ItemTitle>
         <ItemDescription className="font-mono">{preview}</ItemDescription>
         <ItemDescription>
+          {apiKeyLocalization.created}{" "}
           {new Date(apiKey.createdAt).toLocaleString(undefined, {
             dateStyle: "medium",
             timeStyle: "short"
           })}
+        </ItemDescription>
+        <ItemDescription>
+          {apiKey.expiresAt
+            ? `${apiKeyLocalization.expires} ${new Date(
+                apiKey.expiresAt
+              ).toLocaleString(undefined, {
+                dateStyle: "medium",
+                timeStyle: "short"
+              })}`
+            : apiKeyLocalization.neverExpires}
         </ItemDescription>
       </ItemContent>
       <ItemActions>

--- a/examples/start-shadcn-example/src/components/auth/api-key/create-api-key-dialog.tsx
+++ b/examples/start-shadcn-example/src/components/auth/api-key/create-api-key-dialog.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { apiKeyExpirationDaysToSeconds } from "@better-auth-ui/core/plugins"
 import {
   type ApiKeyAuthClient,
   useAuth,
@@ -18,8 +19,21 @@ import {
   DialogHeader,
   DialogTitle
 } from "@/components/ui/dialog"
-import { Field, FieldError, FieldLabel } from "@/components/ui/field"
+import {
+  Field,
+  FieldError,
+  FieldGroup,
+  FieldLabel
+} from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select"
 import { Spinner } from "@/components/ui/spinner"
 import { apiKeyPlugin } from "@/lib/auth/api-key-plugin"
 import { NewApiKeyDialog } from "./new-api-key-dialog"
@@ -37,7 +51,8 @@ export function CreateApiKeyDialog({
   organizationId
 }: CreateApiKeyDialogProps) {
   const { authClient, localization } = useAuth()
-  const { localization: apiKeyLocalization } = useAuthPlugin(apiKeyPlugin)
+  const { keyExpiration, localization: apiKeyLocalization } =
+    useAuthPlugin(apiKeyPlugin)
 
   const { mutate: createApiKey, isPending: isCreating } = useCreateApiKey(
     authClient as ApiKeyAuthClient
@@ -70,18 +85,22 @@ export function CreateApiKeyDialog({
 
     const formData = new FormData(e.target as HTMLFormElement)
     const name = (formData.get("name") as string).trim()
-
-    const payload =
-      name || organizationId
-        ? {
-            ...(name ? { name } : {}),
-            ...(organizationId
-              ? { organizationId, configId: "organization" }
-              : {})
-          }
+    const expiration = formData.get("expiration")
+    const expirationDays =
+      typeof expiration === "string" && expiration !== "never"
+        ? Number(expiration)
         : undefined
+    const expiresIn = expirationDays
+      ? apiKeyExpirationDaysToSeconds(expirationDays)
+      : undefined
 
-    createApiKey(payload, {
+    const payload = {
+      ...(name ? { name } : {}),
+      ...(expiresIn ? { expiresIn } : {}),
+      ...(organizationId ? { organizationId, configId: "organization" } : {})
+    }
+
+    createApiKey(Object.keys(payload).length > 0 ? payload : undefined, {
       onSuccess: (result) => {
         handleOpenChange(false)
         setKeyName(name)
@@ -107,21 +126,64 @@ export function CreateApiKeyDialog({
               </DialogDescription>
             </DialogHeader>
 
-            <Field>
-              <FieldLabel htmlFor="api-key-name">
-                {apiKeyLocalization.name}
-              </FieldLabel>
+            <FieldGroup>
+              <Field>
+                <FieldLabel htmlFor="api-key-name">
+                  {apiKeyLocalization.name}
+                </FieldLabel>
 
-              <Input
-                id="api-key-name"
-                name="name"
-                autoFocus
-                placeholder={localization.settings.optional}
-                disabled={isCreating}
-              />
+                <Input
+                  id="api-key-name"
+                  name="name"
+                  autoFocus
+                  placeholder={localization.settings.optional}
+                  disabled={isCreating}
+                />
 
-              <FieldError />
-            </Field>
+                <FieldError />
+              </Field>
+
+              {keyExpiration ? (
+                <Field>
+                  <FieldLabel htmlFor="api-key-expiration">
+                    {apiKeyLocalization.expiration}
+                  </FieldLabel>
+
+                  <Select
+                    name="expiration"
+                    defaultValue={
+                      keyExpiration.defaultInterval === null
+                        ? "never"
+                        : String(keyExpiration.defaultInterval)
+                    }
+                    disabled={isCreating}
+                  >
+                    <SelectTrigger id="api-key-expiration" className="w-full">
+                      <SelectValue />
+                    </SelectTrigger>
+
+                    <SelectContent>
+                      <SelectGroup>
+                        {keyExpiration.intervals.map((days) => (
+                          <SelectItem key={days} value={String(days)}>
+                            {days.toLocaleString()}{" "}
+                            {days === 1
+                              ? apiKeyLocalization.day
+                              : apiKeyLocalization.days}
+                          </SelectItem>
+                        ))}
+
+                        {keyExpiration.allowNever ? (
+                          <SelectItem value="never">
+                            {apiKeyLocalization.never}
+                          </SelectItem>
+                        ) : null}
+                      </SelectGroup>
+                    </SelectContent>
+                  </Select>
+                </Field>
+              ) : null}
+            </FieldGroup>
 
             <DialogFooter>
               <DialogClose

--- a/examples/start-solid-zaidan-example/src/components/auth/api-key/api-key.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/api-key/api-key.tsx
@@ -1,5 +1,4 @@
-import { apiKeyLocalization } from "@better-auth-ui/core/plugins"
-import { useAuth } from "@better-auth-ui/solid"
+import { useAuth, useAuthPlugin } from "@better-auth-ui/solid"
 import { Key, X } from "lucide-solid"
 import { createSignal, Show } from "solid-js"
 import { DeleteApiKeyDialog } from "@/components/auth/api-key/delete-api-key-dialog"
@@ -14,6 +13,7 @@ import {
   ItemMedia,
   ItemTitle
 } from "@/components/ui/item"
+import { apiKeyPlugin } from "@/lib/auth/api-key-plugin"
 
 export function ApiKey(props: {
   apiKey: ListedApiKey
@@ -21,6 +21,7 @@ export function ApiKey(props: {
   hideDelete?: boolean
 }) {
   const auth = useAuth()
+  const { localization: apiKeyLocalization } = useAuthPlugin(apiKeyPlugin)
   const [deleteOpen, setDeleteOpen] = createSignal(false)
   const preview = () => `${props.apiKey.start}${"*".repeat(16)}`
 
@@ -33,10 +34,21 @@ export function ApiKey(props: {
         <ItemTitle>{props.apiKey.name || apiKeyLocalization.apiKey}</ItemTitle>
         <ItemDescription class="font-mono">{preview()}</ItemDescription>
         <ItemDescription>
+          {apiKeyLocalization.created}{" "}
           {new Date(props.apiKey.createdAt).toLocaleString(undefined, {
             dateStyle: "medium",
             timeStyle: "short"
           })}
+        </ItemDescription>
+        <ItemDescription>
+          {props.apiKey.expiresAt
+            ? `${apiKeyLocalization.expires} ${new Date(
+                props.apiKey.expiresAt
+              ).toLocaleString(undefined, {
+                dateStyle: "medium",
+                timeStyle: "short"
+              })}`
+            : apiKeyLocalization.neverExpires}
         </ItemDescription>
       </ItemContent>
       <ItemActions>

--- a/examples/start-solid-zaidan-example/src/components/auth/api-key/create-api-key-dialog.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/api-key/create-api-key-dialog.tsx
@@ -1,12 +1,13 @@
-import { apiKeyLocalization } from "@better-auth-ui/core/plugins"
+import { apiKeyExpirationDaysToSeconds } from "@better-auth-ui/core/plugins"
 import {
   type ApiKeyAuthClient,
   createApiKeyOptions,
-  useAuth
+  useAuth,
+  useAuthPlugin
 } from "@better-auth-ui/solid"
 import { createMutation } from "@tanstack/solid-query"
 import { Key } from "lucide-solid"
-import { createSignal } from "solid-js"
+import { createSignal, Show } from "solid-js"
 import { NewApiKeyDialog } from "@/components/auth/api-key/new-api-key-dialog"
 import { Button } from "@/components/ui/button"
 import {
@@ -18,14 +19,58 @@ import {
   DialogHeader,
   DialogTitle
 } from "@/components/ui/dialog"
-import { Field, FieldLabel } from "@/components/ui/field"
+import { Field, FieldGroup, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select"
+import { apiKeyPlugin } from "@/lib/auth/api-key-plugin"
+
+type ExpirationOption = {
+  id: string
+  label: string
+  days: number | null
+}
 
 export function CreateApiKeyDialog(props: {
   organizationId?: string
   onOpenChange: (open: boolean) => void
 }) {
   const auth = useAuth()
+  const { keyExpiration, localization: apiKeyLocalization } =
+    useAuthPlugin(apiKeyPlugin)
+  const expirationOptions: ExpirationOption[] = keyExpiration
+    ? [
+        ...keyExpiration.intervals.map((days) => ({
+          id: String(days),
+          label: `${days.toLocaleString()} ${
+            days === 1 ? apiKeyLocalization.day : apiKeyLocalization.days
+          }`,
+          days
+        })),
+        ...(keyExpiration.allowNever
+          ? [
+              {
+                id: "never",
+                label: apiKeyLocalization.never,
+                days: null
+              }
+            ]
+          : [])
+      ]
+    : []
+  const defaultExpirationInterval = keyExpiration
+    ? keyExpiration.defaultInterval
+    : undefined
+  const [expiration, setExpiration] = createSignal(
+    expirationOptions.find(
+      (option) => option.days === defaultExpirationInterval
+    )
+  )
   const [isNewKeyDialogOpen, setIsNewKeyDialogOpen] = createSignal(false)
   const [newApiKeyName, setNewApiKeyName] = createSignal<string | null>(null)
   const [newApiKeySecret, setNewApiKeySecret] = createSignal<string | null>(
@@ -55,8 +100,13 @@ export function CreateApiKeyDialog(props: {
 
     const formData = new FormData(event.currentTarget as HTMLFormElement)
     const name = String(formData.get("name") ?? "").trim()
+    const expirationDays = expiration()?.days
+    const expiresIn = expirationDays
+      ? apiKeyExpirationDaysToSeconds(expirationDays)
+      : undefined
     const payload = {
       ...(name ? { name } : {}),
+      ...(expiresIn ? { expiresIn } : {}),
       ...(props.organizationId
         ? { organizationId: props.organizationId, configId: "organization" }
         : {})
@@ -83,18 +133,48 @@ export function CreateApiKeyDialog(props: {
             </DialogDescription>
           </DialogHeader>
 
-          <Field>
-            <FieldLabel for="api-key-name">
-              {apiKeyLocalization.name}
-            </FieldLabel>
-            <Input
-              autofocus
-              disabled={createApiKey.isPending}
-              id="api-key-name"
-              name="name"
-              placeholder={auth.localization.settings.optional}
-            />
-          </Field>
+          <FieldGroup>
+            <Field>
+              <FieldLabel for="api-key-name">
+                {apiKeyLocalization.name}
+              </FieldLabel>
+              <Input
+                autofocus
+                disabled={createApiKey.isPending}
+                id="api-key-name"
+                name="name"
+                placeholder={auth.localization.settings.optional}
+              />
+            </Field>
+
+            <Show when={keyExpiration}>
+              <Field>
+                <FieldLabel for="api-key-expiration">
+                  {apiKeyLocalization.expiration}
+                </FieldLabel>
+                <Select<ExpirationOption>
+                  disabled={createApiKey.isPending}
+                  itemComponent={(itemProps) => (
+                    <SelectItem item={itemProps.item}>
+                      {itemProps.item.rawValue.label}
+                    </SelectItem>
+                  )}
+                  onChange={(option) => setExpiration(option ?? undefined)}
+                  options={expirationOptions}
+                  optionTextValue="label"
+                  optionValue="id"
+                  value={expiration()}
+                >
+                  <SelectTrigger id="api-key-expiration" class="w-full">
+                    <SelectValue<ExpirationOption>>
+                      {(state) => state.selectedOption().label}
+                    </SelectValue>
+                  </SelectTrigger>
+                  <SelectContent />
+                </Select>
+              </Field>
+            </Show>
+          </FieldGroup>
 
           <DialogFooter>
             <DialogClose

--- a/examples/start-solid-zaidan-example/src/stories/api-key.stories.tsx
+++ b/examples/start-solid-zaidan-example/src/stories/api-key.stories.tsx
@@ -6,6 +6,7 @@ import { AuthProvider } from "@/components/auth/auth-provider"
 import type { ListedApiKey } from "@/components/auth/settings/shared/types"
 import { Card, CardContent } from "@/components/ui/card"
 import { ItemSeparator } from "@/components/ui/item"
+import { apiKeyPlugin } from "@/lib/auth/api-key-plugin"
 
 const mockAuthClient = {
   apiKey: {
@@ -18,19 +19,21 @@ const apiKeys = [
     id: "key_live_docs",
     name: "Production API",
     start: "bau_live_",
-    createdAt: new Date("2026-01-12T10:30:00Z")
+    createdAt: new Date("2026-01-12T10:30:00Z"),
+    expiresAt: new Date("2026-10-10T10:30:00Z")
   },
   {
     id: "key_test_docs",
     name: "Test integration",
     start: "bau_test_",
-    createdAt: new Date("2026-02-04T16:45:00Z")
+    createdAt: new Date("2026-02-04T16:45:00Z"),
+    expiresAt: null
   }
 ] as unknown as ListedApiKey[]
 
 function ApiKeyStory() {
   return (
-    <AuthProvider authClient={mockAuthClient}>
+    <AuthProvider authClient={mockAuthClient} plugins={[apiKeyPlugin()]}>
       {() => (
         <main class="mx-auto flex min-h-[420px] w-full max-w-xl items-center justify-center bg-background p-6 text-foreground">
           <div class="flex w-full flex-col gap-6">

--- a/packages/core/src/plugins.ts
+++ b/packages/core/src/plugins.ts
@@ -1,6 +1,7 @@
 export * from "./plugins/admin/admin-localization"
 export * from "./plugins/admin/admin-mutation-keys"
 export * from "./plugins/admin/admin-plugin"
+export * from "./plugins/api-key/api-key-expiration"
 export * from "./plugins/api-key/api-key-localization"
 export * from "./plugins/api-key/api-key-mutation-keys"
 export * from "./plugins/api-key/api-key-plugin"

--- a/packages/core/src/plugins/api-key/api-key-expiration.ts
+++ b/packages/core/src/plugins/api-key/api-key-expiration.ts
@@ -1,0 +1,79 @@
+export const DEFAULT_API_KEY_EXPIRATION_INTERVALS = [30, 90] as const
+
+export const API_KEY_EXPIRATION_SECONDS_PER_DAY = 60 * 60 * 24
+
+export type ApiKeyExpirationOptions = {
+  /**
+   * Expiration intervals to offer, in days.
+   *
+   * Keep these values within the `minExpiresIn` and `maxExpiresIn` limits in
+   * the matching Better Auth API key server configuration.
+   *
+   * @default [30, 90]
+   */
+  intervals?: readonly number[]
+  /**
+   * The interval selected when the create dialog opens, in days.
+   *
+   * Set this to `null` to select "Never". If the value is unavailable, the
+   * first configured interval is selected instead.
+   *
+   * @default 30
+   */
+  defaultInterval?: number | null
+  /**
+   * Let users create a key without a custom expiration interval.
+   *
+   * Better Auth will still apply `keyExpiration.defaultExpiresIn` when the
+   * server defines one.
+   *
+   * @default true
+   */
+  allowNever?: boolean
+}
+
+export type ResolvedApiKeyExpirationOptions = {
+  intervals: number[]
+  defaultInterval: number | null
+  allowNever: boolean
+}
+
+const isExpirationInterval = (value: number) =>
+  Number.isFinite(value) && value > 0
+
+export function resolveApiKeyExpirationOptions(
+  options: ApiKeyExpirationOptions = {}
+): ResolvedApiKeyExpirationOptions | false {
+  const intervals = Array.from(
+    new Set(
+      (options.intervals ?? DEFAULT_API_KEY_EXPIRATION_INTERVALS).filter(
+        isExpirationInterval
+      )
+    )
+  )
+  const allowNever = options.allowNever ?? true
+  const requestedDefault =
+    options.defaultInterval === undefined
+      ? DEFAULT_API_KEY_EXPIRATION_INTERVALS[0]
+      : options.defaultInterval
+
+  if (intervals.length === 0 && !allowNever) {
+    return false
+  }
+
+  const defaultInterval =
+    requestedDefault === null && allowNever
+      ? null
+      : requestedDefault !== null && intervals.includes(requestedDefault)
+        ? requestedDefault
+        : (intervals[0] ?? null)
+
+  return {
+    intervals,
+    defaultInterval,
+    allowNever
+  }
+}
+
+export const apiKeyExpirationDaysToSeconds = (days: number) =>
+  days * API_KEY_EXPIRATION_SECONDS_PER_DAY

--- a/packages/core/src/plugins/api-key/api-key-localization.ts
+++ b/packages/core/src/plugins/api-key/api-key-localization.ts
@@ -12,6 +12,20 @@ export const apiKeyLocalization = {
   noApiKeys: "No API keys",
   /** @remarks `"Name"` */
   name: "Name",
+  /** @remarks `"Expiration"` */
+  expiration: "Expiration",
+  /** @remarks `"day"` */
+  day: "day",
+  /** @remarks `"days"` */
+  days: "days",
+  /** @remarks `"Never"` */
+  never: "Never",
+  /** @remarks `"Created"` */
+  created: "Created",
+  /** @remarks `"Expires"` */
+  expires: "Expires",
+  /** @remarks `"Never expires"` */
+  neverExpires: "Never expires",
   /** @remarks `"New API key"` */
   newApiKey: "New API key",
   /** @remarks `"Copy this key now. For security reasons you will not be able to see it again."` */

--- a/packages/core/src/plugins/api-key/api-key-plugin.ts
+++ b/packages/core/src/plugins/api-key/api-key-plugin.ts
@@ -1,5 +1,9 @@
 import { createAuthPlugin } from "../../lib/create-auth-plugin"
 import {
+  type ApiKeyExpirationOptions,
+  resolveApiKeyExpirationOptions
+} from "./api-key-expiration"
+import {
   type ApiKeyLocalization,
   apiKeyLocalization
 } from "./api-key-localization"
@@ -30,12 +34,30 @@ export type ApiKeyPluginOptions = {
    * @default false
    */
   organization?: boolean
+  /**
+   * Configure the expiration choices shown when a user creates an API key.
+   *
+   * Set this to `false` to hide the expiration field and preserve the Better
+   * Auth server default. Intervals are configured in days and sent to Better
+   * Auth as seconds.
+   *
+   * @default { intervals: [30, 90], defaultInterval: 30, allowNever: true }
+   */
+  keyExpiration?: ApiKeyExpirationOptions | false
 }
 
 export const apiKeyPlugin = createAuthPlugin(
   "apiKey",
-  (options: ApiKeyPluginOptions = {}) => ({
-    localization: { ...apiKeyLocalization, ...options.localization },
-    organization: options.organization ?? false
-  })
+  (options: ApiKeyPluginOptions = {}) => {
+    const keyExpiration =
+      options.keyExpiration === false
+        ? false
+        : resolveApiKeyExpirationOptions(options.keyExpiration)
+
+    return {
+      localization: { ...apiKeyLocalization, ...options.localization },
+      organization: options.organization ?? false,
+      keyExpiration
+    }
+  }
 )

--- a/packages/core/tests/api-key-plugin.test.ts
+++ b/packages/core/tests/api-key-plugin.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest"
+import {
+  API_KEY_EXPIRATION_SECONDS_PER_DAY,
+  apiKeyExpirationDaysToSeconds,
+  apiKeyPlugin,
+  DEFAULT_API_KEY_EXPIRATION_INTERVALS,
+  resolveApiKeyExpirationOptions
+} from "../src/plugins"
+
+describe("apiKeyPlugin", () => {
+  it("offers expiring and non-expiring keys by default", () => {
+    expect(apiKeyPlugin()).toMatchObject({
+      id: "apiKey",
+      organization: false,
+      keyExpiration: {
+        intervals: [...DEFAULT_API_KEY_EXPIRATION_INTERVALS],
+        defaultInterval: 30,
+        allowNever: true
+      }
+    })
+  })
+
+  it("supports opting out of the expiration control", () => {
+    expect(apiKeyPlugin({ keyExpiration: false }).keyExpiration).toBe(false)
+  })
+
+  it("normalizes custom intervals and selects an available default", () => {
+    expect(
+      resolveApiKeyExpirationOptions({
+        intervals: [7, 30, 7, Number.NaN, 0, -1],
+        defaultInterval: 90,
+        allowNever: false
+      })
+    ).toEqual({
+      intervals: [7, 30],
+      defaultInterval: 7,
+      allowNever: false
+    })
+  })
+
+  it("keeps Never selected when it is allowed", () => {
+    expect(
+      resolveApiKeyExpirationOptions({
+        intervals: [7],
+        defaultInterval: null
+      })
+    ).toEqual({
+      intervals: [7],
+      defaultInterval: null,
+      allowNever: true
+    })
+  })
+
+  it("disables an empty expiration control without a Never option", () => {
+    expect(
+      resolveApiKeyExpirationOptions({
+        intervals: [],
+        allowNever: false
+      })
+    ).toBe(false)
+  })
+
+  it("converts configured days to Better Auth seconds", () => {
+    expect(apiKeyExpirationDaysToSeconds(30)).toBe(
+      30 * API_KEY_EXPIRATION_SECONDS_PER_DAY
+    )
+  })
+})

--- a/packages/heroui/src/components/auth/api-key/api-key.tsx
+++ b/packages/heroui/src/components/auth/api-key/api-key.tsx
@@ -39,10 +39,22 @@ export function ApiKey({ apiKey, hideDelete, organizationId }: ApiKeyProps) {
         <span className="text-xs text-muted font-mono truncate">{preview}</span>
 
         <span className="text-xs text-muted">
+          {apiKeyLocalization.created}{" "}
           {new Date(apiKey.createdAt).toLocaleString(undefined, {
             dateStyle: "medium",
             timeStyle: "short"
           })}
+        </span>
+
+        <span className="text-xs text-muted">
+          {apiKey.expiresAt
+            ? `${apiKeyLocalization.expires} ${new Date(
+                apiKey.expiresAt
+              ).toLocaleString(undefined, {
+                dateStyle: "medium",
+                timeStyle: "short"
+              })}`
+            : apiKeyLocalization.neverExpires}
         </span>
       </div>
 

--- a/packages/heroui/src/components/auth/api-key/create-api-key-dialog.tsx
+++ b/packages/heroui/src/components/auth/api-key/create-api-key-dialog.tsx
@@ -1,3 +1,4 @@
+import { apiKeyExpirationDaysToSeconds } from "@better-auth-ui/core/plugins"
 import {
   type ApiKeyAuthClient,
   useAuth,
@@ -12,6 +13,8 @@ import {
   Form,
   Input,
   Label,
+  ListBox,
+  Select,
   Spinner,
   TextField
 } from "@heroui/react"
@@ -34,7 +37,8 @@ export function CreateApiKeyDialog({
   organizationId
 }: CreateApiKeyDialogProps) {
   const { authClient, localization } = useAuth()
-  const { localization: apiKeyLocalization } = useAuthPlugin(apiKeyPlugin)
+  const { keyExpiration, localization: apiKeyLocalization } =
+    useAuthPlugin(apiKeyPlugin)
 
   const { mutate: createApiKey, isPending: isCreating } = useCreateApiKey(
     authClient as ApiKeyAuthClient
@@ -67,18 +71,22 @@ export function CreateApiKeyDialog({
 
     const formData = new FormData(e.target as HTMLFormElement)
     const name = (formData.get("name") as string)?.trim()
-
-    const payload =
-      name || organizationId
-        ? {
-            ...(name ? { name } : {}),
-            ...(organizationId
-              ? { organizationId, configId: "organization" }
-              : {})
-          }
+    const expiration = formData.get("expiration")
+    const expirationDays =
+      typeof expiration === "string" && expiration !== "never"
+        ? Number(expiration)
         : undefined
+    const expiresIn = expirationDays
+      ? apiKeyExpirationDaysToSeconds(expirationDays)
+      : undefined
 
-    createApiKey(payload, {
+    const payload = {
+      ...(name ? { name } : {}),
+      ...(expiresIn ? { expiresIn } : {}),
+      ...(organizationId ? { organizationId, configId: "organization" } : {})
+    }
+
+    createApiKey(Object.keys(payload).length > 0 ? payload : undefined, {
       onSuccess: (result) => {
         handleOpenChange(false)
         setKeyName(name)
@@ -111,22 +119,72 @@ export function CreateApiKeyDialog({
                   {apiKeyLocalization.apiKeysDescription}
                 </p>
 
-                <TextField
-                  className="mt-4"
-                  id="name"
-                  name="name"
-                  isDisabled={isCreating}
-                >
-                  <Label>{apiKeyLocalization.name}</Label>
+                <div className="mt-4 flex flex-col gap-4">
+                  <TextField id="name" name="name" isDisabled={isCreating}>
+                    <Label>{apiKeyLocalization.name}</Label>
 
-                  <Input
-                    autoFocus
-                    placeholder={localization.settings.optional}
-                    variant="secondary"
-                  />
+                    <Input
+                      autoFocus
+                      placeholder={localization.settings.optional}
+                      variant="secondary"
+                    />
 
-                  <FieldError />
-                </TextField>
+                    <FieldError />
+                  </TextField>
+
+                  {keyExpiration ? (
+                    <Select
+                      defaultValue={
+                        keyExpiration.defaultInterval === null
+                          ? "never"
+                          : String(keyExpiration.defaultInterval)
+                      }
+                      fullWidth
+                      isDisabled={isCreating}
+                      name="expiration"
+                      variant="secondary"
+                    >
+                      <Label>{apiKeyLocalization.expiration}</Label>
+
+                      <Select.Trigger>
+                        <Select.Value />
+                        <Select.Indicator />
+                      </Select.Trigger>
+
+                      <Select.Popover>
+                        <ListBox>
+                          {keyExpiration.intervals.map((days) => (
+                            <ListBox.Item
+                              id={String(days)}
+                              key={days}
+                              textValue={`${days.toLocaleString()} ${
+                                days === 1
+                                  ? apiKeyLocalization.day
+                                  : apiKeyLocalization.days
+                              }`}
+                            >
+                              {days.toLocaleString()}{" "}
+                              {days === 1
+                                ? apiKeyLocalization.day
+                                : apiKeyLocalization.days}
+                              <ListBox.ItemIndicator />
+                            </ListBox.Item>
+                          ))}
+
+                          {keyExpiration.allowNever ? (
+                            <ListBox.Item
+                              id="never"
+                              textValue={apiKeyLocalization.never}
+                            >
+                              {apiKeyLocalization.never}
+                              <ListBox.ItemIndicator />
+                            </ListBox.Item>
+                          ) : null}
+                        </ListBox>
+                      </Select.Popover>
+                    </Select>
+                  ) : null}
+                </div>
               </AlertDialog.Body>
 
               <AlertDialog.Footer>

--- a/packages/heroui/tests/api-key.test.tsx
+++ b/packages/heroui/tests/api-key.test.tsx
@@ -1,13 +1,21 @@
+import { API_KEY_EXPIRATION_SECONDS_PER_DAY } from "@better-auth-ui/core/plugins"
 import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { useState } from "react"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
+import { CreateApiKeyDialog } from "../src/components/auth/api-key/create-api-key-dialog"
 import { NewApiKeyDialog } from "../src/components/auth/api-key/new-api-key-dialog"
 import { AuthProvider } from "../src/components/auth/auth-provider"
 import { apiKeyPlugin } from "../src/lib/auth/api-key-plugin"
 
-function createMockAuthClient() {
+function createMockAuthClient(
+  create = vi.fn(async () => ({
+    key: "api-key-secret",
+    name: null
+  }))
+) {
   return {
+    apiKey: { create },
     useSession: () => ({ data: null, isPending: false, error: null })
   } as unknown as Parameters<typeof AuthProvider>[0]["authClient"]
 }
@@ -44,5 +52,50 @@ describe("<NewApiKeyDialog />", () => {
     await waitFor(() => {
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
     })
+  })
+})
+
+describe("<CreateApiKeyDialog />", () => {
+  it("sends the default expiration interval to Better Auth in seconds", async () => {
+    const user = userEvent.setup()
+    const create = vi.fn(async () => ({
+      key: "api-key-secret",
+      name: null
+    }))
+
+    render(
+      <AuthProvider
+        authClient={createMockAuthClient(create)}
+        navigate={() => {}}
+        plugins={[apiKeyPlugin()]}
+      >
+        <CreateApiKeyDialog isOpen onOpenChange={() => {}} />
+      </AuthProvider>
+    )
+
+    await user.click(
+      screen.getByRole("button", { name: "Create API key", exact: true })
+    )
+
+    await waitFor(() => {
+      expect(create).toHaveBeenCalledWith({
+        expiresIn: 30 * API_KEY_EXPIRATION_SECONDS_PER_DAY,
+        fetchOptions: { throw: true }
+      })
+    })
+  })
+
+  it("hides the expiration field when the plugin opts out", () => {
+    render(
+      <AuthProvider
+        authClient={createMockAuthClient()}
+        navigate={() => {}}
+        plugins={[apiKeyPlugin({ keyExpiration: false })]}
+      >
+        <CreateApiKeyDialog isOpen onOpenChange={() => {}} />
+      </AuthProvider>
+    )
+
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary

- add shared API-key expiration options with configurable day intervals, a configurable default, a Never choice, and a `keyExpiration: false` opt-out
- support expiration selection and expiry-date display across shadcn, Base UI, HeroUI, and Solid/Zaidan
- document the client and server expiration settings for every supported platform and add focused core and HeroUI coverage

## Validation

- `bunx biome check .`
- `bun nx run docs:lint`
- core and HeroUI tests: 251 passed
- docs tests: 12 passed
- Solid/Zaidan tests: 104 passed
- shadcn and Solid registry builds
- affected core, HeroUI, shadcn, Base UI, and Solid/Zaidan production builds
- Zaidan Storybook build

The full docs production bundle was also attempted. MDX generation and Storybook completed, but the final Vite bundle exceeded the existing 10 GB Node heap limit in this environment.

Closes #440

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable API key expiration options, including custom intervals and “Never” expiration.
  * API key creation dialogs now let users select an expiration period.
  * API key lists display creation and expiration dates, including never-expiring keys.
  * Added localized labels and guidance for expiration settings.

* **Documentation**
  * Expanded API key plugin documentation with configuration examples and server-side alignment guidance.

* **Tests**
  * Added coverage for expiration configuration, conversion, creation, and disabled expiration controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->