### PR TITLE
fix(auth): preserve configured redirect paths

### DIFF
--- a/apps/docs/.cache/fumadocs-typescript/0688811fa2c2.json
+++ b/apps/docs/.cache/fumadocs-typescript/0688811fa2c2.json
@@ -1,0 +1,27 @@
+[
+  {
+    "id": "reset-password-otp.tsx-ResetPasswordOtpProps",
+    "name": "ResetPasswordOtpProps",
+    "description": "",
+    "entries": [
+      {
+        "name": "className",
+        "description": "",
+        "tags": [],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "variant",
+        "description": "",
+        "tags": [],
+        "type": "\"default\" | \"secondary\" | \"tertiary\" | \"transparent\"",
+        "simplifiedType": "\"default\" | \"secondary\" | \"tertiary\" | \"transparent\"",
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  }
+]

--- a/apps/docs/.cache/fumadocs-typescript/1161cd85e860.json
+++ b/apps/docs/.cache/fumadocs-typescript/1161cd85e860.json
@@ -1,0 +1,72 @@
+[
+  {
+    "id": "user-button.tsx-UserButtonProps",
+    "name": "UserButtonProps",
+    "description": "",
+    "entries": [
+      {
+        "name": "class",
+        "description": "",
+        "tags": [],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "align",
+        "description": "",
+        "tags": [],
+        "type": "\"center\" | \"end\" | \"start\"",
+        "simplifiedType": "\"center\" | \"end\" | \"start\"",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "hideSettings",
+        "description": "",
+        "tags": [],
+        "type": "boolean",
+        "simplifiedType": "boolean",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "links",
+        "description": "",
+        "tags": [],
+        "type": "(UserButtonLink | JSX.Element)[]",
+        "simplifiedType": "array",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "sideOffset",
+        "description": "",
+        "tags": [],
+        "type": "number",
+        "simplifiedType": "number",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "size",
+        "description": "",
+        "tags": [],
+        "type": "\"default\" | \"icon\"",
+        "simplifiedType": "\"default\" | \"icon\"",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "variant",
+        "description": "",
+        "tags": [],
+        "type": "\"default\" | \"destructive\" | \"ghost\" | \"link\" | \"outline\" | \"secondary\"",
+        "simplifiedType": "\"default\" | \"destructive\" | \"ghost\" | \"link\" | \"outline\" | \"secondary\"",
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  }
+]

--- a/apps/docs/.cache/fumadocs-typescript/165c3ae7e7b7.json
+++ b/apps/docs/.cache/fumadocs-typescript/165c3ae7e7b7.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "verify-email-otp.tsx-VerifyEmailOtpProps",
+    "name": "VerifyEmailOtpProps",
+    "description": "",
+    "entries": [
+      {
+        "name": "class",
+        "description": "",
+        "tags": [],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  }
+]

--- a/apps/docs/.cache/fumadocs-typescript/1916d4d8a30a.json
+++ b/apps/docs/.cache/fumadocs-typescript/1916d4d8a30a.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "change-email.tsx-ChangeEmailProps",
+    "name": "ChangeEmailProps",
+    "description": "",
+    "entries": [
+      {
+        "name": "class",
+        "description": "",
+        "tags": [],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  }
+]

--- a/apps/docs/.cache/fumadocs-typescript/28c5de02a638.json
+++ b/apps/docs/.cache/fumadocs-typescript/28c5de02a638.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "verify-email-otp.tsx-VerifyEmailOtpProps",
+    "name": "VerifyEmailOtpProps",
+    "description": "",
+    "entries": [
+      {
+        "name": "className",
+        "description": "",
+        "tags": [],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  }
+]

--- a/apps/docs/.cache/fumadocs-typescript/3371f2949ca6.json
+++ b/apps/docs/.cache/fumadocs-typescript/3371f2949ca6.json
@@ -1,0 +1,27 @@
+[
+  {
+    "id": "change-password.tsx-ChangePasswordProps",
+    "name": "ChangePasswordProps",
+    "description": "",
+    "entries": [
+      {
+        "name": "className",
+        "description": "",
+        "tags": [],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "variant",
+        "description": "",
+        "tags": [],
+        "type": "\"default\" | \"secondary\" | \"tertiary\" | \"transparent\"",
+        "simplifiedType": "\"default\" | \"secondary\" | \"tertiary\" | \"transparent\"",
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  }
+]

--- a/apps/docs/.cache/fumadocs-typescript/3d158c5eb2fe.json
+++ b/apps/docs/.cache/fumadocs-typescript/3d158c5eb2fe.json
@@ -1,0 +1,45 @@
+[
+  {
+    "id": "sign-up.tsx-SignUpProps",
+    "name": "SignUpProps",
+    "description": "",
+    "entries": [
+      {
+        "name": "class",
+        "description": "",
+        "tags": [],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "socialLayout",
+        "description": "",
+        "tags": [],
+        "type": "SocialLayout",
+        "simplifiedType": "SocialLayout",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "socialPosition",
+        "description": "",
+        "tags": [],
+        "type": "\"top\" | \"bottom\"",
+        "simplifiedType": "\"top\" | \"bottom\"",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "onSignUpSuccess",
+        "description": "Runs instead of the post-sign-up redirect, but only when the sign-up\ncreated an immediately usable session. Email verification still takes\npriority, and social sign-ups are unaffected.",
+        "tags": [],
+        "type": "(() => void)",
+        "simplifiedType": "function",
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  }
+]

--- a/apps/docs/.cache/fumadocs-typescript/3e58ed5beacb.json
+++ b/apps/docs/.cache/fumadocs-typescript/3e58ed5beacb.json
@@ -1,0 +1,54 @@
+[
+  {
+    "id": "sign-up.tsx-SignUpProps",
+    "name": "SignUpProps",
+    "description": "",
+    "entries": [
+      {
+        "name": "className",
+        "description": "",
+        "tags": [],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "socialLayout",
+        "description": "",
+        "tags": [],
+        "type": "SocialLayout",
+        "simplifiedType": "SocialLayout",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "socialPosition",
+        "description": "",
+        "tags": [],
+        "type": "\"top\" | \"bottom\"",
+        "simplifiedType": "\"top\" | \"bottom\"",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "variant",
+        "description": "",
+        "tags": [],
+        "type": "\"default\" | \"secondary\" | \"tertiary\" | \"transparent\"",
+        "simplifiedType": "\"default\" | \"secondary\" | \"tertiary\" | \"transparent\"",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "onSignUpSuccess",
+        "description": "Runs instead of the post-sign-up redirect, but only when the sign-up\ncreated an immediately usable session. Email verification still takes\npriority, and social sign-ups are unaffected.",
+        "tags": [],
+        "type": "(() => void)",
+        "simplifiedType": "function",
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  }
+]

--- a/apps/docs/.cache/fumadocs-typescript/3e78befc0a3f.json
+++ b/apps/docs/.cache/fumadocs-typescript/3e78befc0a3f.json
@@ -1,0 +1,27 @@
+[
+  {
+    "id": "reset-password.tsx-ResetPasswordProps",
+    "name": "ResetPasswordProps",
+    "description": "",
+    "entries": [
+      {
+        "name": "class",
+        "description": "",
+        "tags": [],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "token",
+        "description": "",
+        "tags": [],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  }
+]

--- a/apps/docs/.cache/fumadocs-typescript/42b4793a80a9.json
+++ b/apps/docs/.cache/fumadocs-typescript/42b4793a80a9.json
@@ -1,0 +1,36 @@
+[
+  {
+    "id": "magic-link.tsx-MagicLinkProps",
+    "name": "MagicLinkProps",
+    "description": "",
+    "entries": [
+      {
+        "name": "class",
+        "description": "",
+        "tags": [],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "socialLayout",
+        "description": "",
+        "tags": [],
+        "type": "SocialLayout",
+        "simplifiedType": "SocialLayout",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "socialPosition",
+        "description": "",
+        "tags": [],
+        "type": "\"bottom\" | \"top\"",
+        "simplifiedType": "\"bottom\" | \"top\"",
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  }
+]

--- a/apps/docs/.cache/fumadocs-typescript/4df6b431e1c2.json
+++ b/apps/docs/.cache/fumadocs-typescript/4df6b431e1c2.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "reset-password-otp.tsx-ResetPasswordOtpProps",
+    "name": "ResetPasswordOtpProps",
+    "description": "",
+    "entries": [
+      {
+        "name": "className",
+        "description": "",
+        "tags": [],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  }
+]

--- a/apps/docs/.cache/fumadocs-typescript/56fda7aa0e70.json
+++ b/apps/docs/.cache/fumadocs-typescript/56fda7aa0e70.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "magic-link-sent.tsx-MagicLinkSentProps",
+    "name": "MagicLinkSentProps",
+    "description": "",
+    "entries": [
+      {
+        "name": "class",
+        "description": "",
+        "tags": [],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  }
+]

--- a/apps/docs/.cache/fumadocs-typescript/5907890d6e1d.json
+++ b/apps/docs/.cache/fumadocs-typescript/5907890d6e1d.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "reset-link-sent.tsx-ResetLinkSentProps",
+    "name": "ResetLinkSentProps",
+    "description": "",
+    "entries": [
+      {
+        "name": "class",
+        "description": "",
+        "tags": [],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  }
+]

--- a/apps/docs/.cache/fumadocs-typescript/590fb187545b.json
+++ b/apps/docs/.cache/fumadocs-typescript/590fb187545b.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "reset-link-sent.tsx-ResetLinkSentProps",
+    "name": "ResetLinkSentProps",
+    "description": "",
+    "entries": [
+      {
+        "name": "className",
+        "description": "",
+        "tags": [],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  }
+]

--- a/apps/docs/.cache/fumadocs-typescript/5e1849c88797.json
+++ b/apps/docs/.cache/fumadocs-typescript/5e1849c88797.json
@@ -1,0 +1,27 @@
+[
+  {
+    "id": "forgot-password.tsx-ForgotPasswordProps",
+    "name": "ForgotPasswordProps",
+    "description": "",
+    "entries": [
+      {
+        "name": "class",
+        "description": "",
+        "tags": [],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "redirectTo",
+        "description": "",
+        "tags": [],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  }
+]

--- a/apps/docs/.cache/fumadocs-typescript/60d3766b2bfd.json
+++ b/apps/docs/.cache/fumadocs-typescript/60d3766b2bfd.json
@@ -1,0 +1,27 @@
+[
+  {
+    "id": "reset-password.tsx-ResetPasswordProps",
+    "name": "ResetPasswordProps",
+    "description": "",
+    "entries": [
+      {
+        "name": "class",
+        "description": "",
+        "tags": [],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "token",
+        "description": "",
+        "tags": [],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  }
+]

--- a/apps/docs/.cache/fumadocs-typescript/79fce36186e8.json
+++ b/apps/docs/.cache/fumadocs-typescript/79fce36186e8.json
@@ -1,0 +1,27 @@
+[
+  {
+    "id": "reset-password.tsx-ResetPasswordProps",
+    "name": "ResetPasswordProps",
+    "description": "",
+    "entries": [
+      {
+        "name": "className",
+        "description": "",
+        "tags": [],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "variant",
+        "description": "",
+        "tags": [],
+        "type": "\"default\" | \"secondary\" | \"tertiary\" | \"transparent\"",
+        "simplifiedType": "\"default\" | \"secondary\" | \"tertiary\" | \"transparent\"",
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  }
+]

--- a/apps/docs/.cache/fumadocs-typescript/7c04178dd8f6.json
+++ b/apps/docs/.cache/fumadocs-typescript/7c04178dd8f6.json
@@ -1,0 +1,27 @@
+[
+  {
+    "id": "reset-password.tsx-ResetPasswordProps",
+    "name": "ResetPasswordProps",
+    "description": "",
+    "entries": [
+      {
+        "name": "className",
+        "description": "",
+        "tags": [],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "variant",
+        "description": "",
+        "tags": [],
+        "type": "\"default\" | \"secondary\" | \"tertiary\" | \"transparent\"",
+        "simplifiedType": "\"default\" | \"secondary\" | \"tertiary\" | \"transparent\"",
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  }
+]

--- a/apps/docs/.cache/fumadocs-typescript/7ceff50230e8.json
+++ b/apps/docs/.cache/fumadocs-typescript/7ceff50230e8.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "reset-password.tsx-ResetPasswordProps",
+    "name": "ResetPasswordProps",
+    "description": "",
+    "entries": [
+      {
+        "name": "className",
+        "description": "",
+        "tags": [],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  }
+]

--- a/apps/docs/.cache/fumadocs-typescript/7ec098a8627c.json
+++ b/apps/docs/.cache/fumadocs-typescript/7ec098a8627c.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "reset-link-sent.tsx-ResetLinkSentProps",
+    "name": "ResetLinkSentProps",
+    "description": "",
+    "entries": [
+      {
+        "name": "class",
+        "description": "",
+        "tags": [],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  }
+]

--- a/apps/docs/.cache/fumadocs-typescript/849d39136e6f.json
+++ b/apps/docs/.cache/fumadocs-typescript/849d39136e6f.json
@@ -1,0 +1,45 @@
+[
+  {
+    "id": "sign-up.tsx-SignUpProps",
+    "name": "SignUpProps",
+    "description": "",
+    "entries": [
+      {
+        "name": "class",
+        "description": "",
+        "tags": [],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "socialLayout",
+        "description": "",
+        "tags": [],
+        "type": "SocialLayout",
+        "simplifiedType": "SocialLayout",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "socialPosition",
+        "description": "",
+        "tags": [],
+        "type": "\"top\" | \"bottom\"",
+        "simplifiedType": "\"top\" | \"bottom\"",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "onSignUpSuccess",
+        "description": "Runs instead of the post-sign-up redirect, but only when the sign-up\ncreated an immediately usable session. Email verification still takes\npriority, and social sign-ups are unaffected.",
+        "tags": [],
+        "type": "(() => void)",
+        "simplifiedType": "function",
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  }
+]

--- a/apps/docs/.cache/fumadocs-typescript/87d1db3ff73b.json
+++ b/apps/docs/.cache/fumadocs-typescript/87d1db3ff73b.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "verify-email.tsx-VerifyEmailProps",
+    "name": "VerifyEmailProps",
+    "description": "",
+    "entries": [
+      {
+        "name": "class",
+        "description": "",
+        "tags": [],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  }
+]

--- a/apps/docs/.cache/fumadocs-typescript/8878c7f278ee.json
+++ b/apps/docs/.cache/fumadocs-typescript/8878c7f278ee.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "reset-password-otp.tsx-ResetPasswordOtpProps",
+    "name": "ResetPasswordOtpProps",
+    "description": "",
+    "entries": [
+      {
+        "name": "class",
+        "description": "",
+        "tags": [],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  }
+]

--- a/apps/docs/.cache/fumadocs-typescript/8f04ac58cc36.json
+++ b/apps/docs/.cache/fumadocs-typescript/8f04ac58cc36.json
@@ -1,0 +1,45 @@
+[
+  {
+    "id": "sign-up.tsx-SignUpProps",
+    "name": "SignUpProps",
+    "description": "",
+    "entries": [
+      {
+        "name": "className",
+        "description": "",
+        "tags": [],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "socialLayout",
+        "description": "",
+        "tags": [],
+        "type": "SocialLayout",
+        "simplifiedType": "SocialLayout",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "socialPosition",
+        "description": "",
+        "tags": [],
+        "type": "\"top\" | \"bottom\"",
+        "simplifiedType": "\"top\" | \"bottom\"",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "onSignUpSuccess",
+        "description": "Runs instead of the post-sign-up redirect, but only when the sign-up\ncreated an immediately usable session. Email verification still takes\npriority, and social sign-ups are unaffected.",
+        "tags": [],
+        "type": "(() => void)",
+        "simplifiedType": "function",
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  }
+]

--- a/apps/docs/.cache/fumadocs-typescript/91e153a263ee.json
+++ b/apps/docs/.cache/fumadocs-typescript/91e153a263ee.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "reset-password-otp.tsx-ResetPasswordOtpProps",
+    "name": "ResetPasswordOtpProps",
+    "description": "",
+    "entries": [
+      {
+        "name": "class",
+        "description": "",
+        "tags": [],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  }
+]

--- a/apps/docs/.cache/fumadocs-typescript/944a693c0812.json
+++ b/apps/docs/.cache/fumadocs-typescript/944a693c0812.json
@@ -1,0 +1,27 @@
+[
+  {
+    "id": "change-email.tsx-ChangeEmailProps",
+    "name": "ChangeEmailProps",
+    "description": "",
+    "entries": [
+      {
+        "name": "className",
+        "description": "",
+        "tags": [],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "variant",
+        "description": "",
+        "tags": [],
+        "type": "\"default\" | \"secondary\" | \"tertiary\" | \"transparent\"",
+        "simplifiedType": "\"default\" | \"secondary\" | \"tertiary\" | \"transparent\"",
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  }
+]

--- a/apps/docs/.cache/fumadocs-typescript/99842e48ac0b.json
+++ b/apps/docs/.cache/fumadocs-typescript/99842e48ac0b.json
@@ -1,0 +1,45 @@
+[
+  {
+    "id": "sign-up.tsx-SignUpProps",
+    "name": "SignUpProps",
+    "description": "",
+    "entries": [
+      {
+        "name": "className",
+        "description": "",
+        "tags": [],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "socialLayout",
+        "description": "",
+        "tags": [],
+        "type": "SocialLayout",
+        "simplifiedType": "SocialLayout",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "socialPosition",
+        "description": "",
+        "tags": [],
+        "type": "\"top\" | \"bottom\"",
+        "simplifiedType": "\"top\" | \"bottom\"",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "onSignUpSuccess",
+        "description": "Runs instead of the post-sign-up redirect, but only when the sign-up\ncreated an immediately usable session. Email verification still takes\npriority, and social sign-ups are unaffected.",
+        "tags": [],
+        "type": "(() => void)",
+        "simplifiedType": "function",
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  }
+]

--- a/apps/docs/.cache/fumadocs-typescript/a14ac85931ed.json
+++ b/apps/docs/.cache/fumadocs-typescript/a14ac85931ed.json
@@ -1,0 +1,27 @@
+[
+  {
+    "id": "reset-link-sent.tsx-ResetLinkSentProps",
+    "name": "ResetLinkSentProps",
+    "description": "",
+    "entries": [
+      {
+        "name": "className",
+        "description": "",
+        "tags": [],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "variant",
+        "description": "",
+        "tags": [],
+        "type": "\"default\" | \"secondary\" | \"tertiary\" | \"transparent\"",
+        "simplifiedType": "\"default\" | \"secondary\" | \"tertiary\" | \"transparent\"",
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  }
+]

--- a/apps/docs/.cache/fumadocs-typescript/a33ef10450bc.json
+++ b/apps/docs/.cache/fumadocs-typescript/a33ef10450bc.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "two-factor-challenge.tsx-TwoFactorChallengeProps",
+    "name": "TwoFactorChallengeProps",
+    "description": "",
+    "entries": [
+      {
+        "name": "class",
+        "description": "",
+        "tags": [],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  }
+]

--- a/apps/docs/.cache/fumadocs-typescript/ae6c2f3dd867.json
+++ b/apps/docs/.cache/fumadocs-typescript/ae6c2f3dd867.json
@@ -1,0 +1,27 @@
+[
+  {
+    "id": "verify-email-otp.tsx-VerifyEmailOtpProps",
+    "name": "VerifyEmailOtpProps",
+    "description": "",
+    "entries": [
+      {
+        "name": "className",
+        "description": "",
+        "tags": [],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "variant",
+        "description": "",
+        "tags": [],
+        "type": "\"default\" | \"secondary\" | \"tertiary\" | \"transparent\"",
+        "simplifiedType": "\"default\" | \"secondary\" | \"tertiary\" | \"transparent\"",
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  }
+]

--- a/apps/docs/.cache/fumadocs-typescript/b5f1613d8d07.json
+++ b/apps/docs/.cache/fumadocs-typescript/b5f1613d8d07.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "forgot-password.tsx-ForgotPasswordProps",
+    "name": "ForgotPasswordProps",
+    "description": "",
+    "entries": [
+      {
+        "name": "className",
+        "description": "",
+        "tags": [],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  }
+]

--- a/apps/docs/.cache/fumadocs-typescript/c053944c6cd6.json
+++ b/apps/docs/.cache/fumadocs-typescript/c053944c6cd6.json
@@ -1,0 +1,178 @@
+[
+  {
+    "id": "auth-provider.tsx-AuthProviderProps",
+    "name": "AuthProviderProps",
+    "description": "",
+    "entries": [
+      {
+        "name": "additionalFields",
+        "description": "Additional user fields rendered on sign-up and the user profile.",
+        "tags": [{ "name": "remarks", "text": "`AdditionalFields`" }],
+        "type": "AdditionalFields",
+        "simplifiedType": "AdditionalFields",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "avatar",
+        "description": "Avatar upload, optimization, and deletion configuration.",
+        "tags": [
+          { "name": "remarks", "text": "`AvatarConfig`" },
+          {
+            "name": "default",
+            "text": "{ enabled: true, resize: resizeAvatar, size: 256, extension: \"png\" }"
+          }
+        ],
+        "type": "{ delete?: ((url: string) => Promise<void>); enabled?: boolean; extension?: \"png\" | \"jpg\" | \"webp\" | \"inherit\"; resize?: ((file: File, size?: number, extension?: \"png\" | \"jpg\" | \"webp\" | \"inherit\") => Promise<File>); size?: number; upload?: ((file: File) => Promise<string>); }",
+        "simplifiedType": "AvatarConfig",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "basePaths",
+        "description": "Base paths for different application sections",
+        "tags": [{ "name": "remarks", "text": "`BasePaths`" }],
+        "type": "{ auth?: string; settings?: string; organization?: string; }",
+        "simplifiedType": "BasePaths",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "baseURL",
+        "description": "Base URL for API endpoints (optional)",
+        "tags": [{ "name": "default", "text": "\"\"" }],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "emailAndPassword",
+        "description": "Email and password authentication configuration",
+        "tags": [{ "name": "remarks", "text": "`EmailAndPasswordConfig`" }],
+        "type": "{ enabled?: boolean; confirmPassword?: boolean; forgotPassword?: boolean; maxPasswordLength?: number; minPasswordLength?: number; name?: boolean; rememberMe?: boolean; requireEmailVerification?: boolean; }",
+        "simplifiedType": "EmailAndPasswordConfig",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "localization",
+        "description": "Localization strings for UI components",
+        "tags": [{ "name": "remarks", "text": "`Localization`" }],
+        "type": "Localization",
+        "simplifiedType": "Localization",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "plugins",
+        "description": "Registered auth plugins. UI packages widen the element type via the\n`AuthPluginRegister` module-augmentation slot.",
+        "tags": [
+          { "name": "remarks", "text": "`AuthPlugin[]`" },
+          { "name": "default", "text": "[]" }
+        ],
+        "type": "SolidAuthPlugin[]",
+        "simplifiedType": "AuthPlugin[]",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "redirectTo",
+        "description": "Default redirect path after successful authentication",
+        "tags": [{ "name": "default", "text": "\"/\"" }],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "multipleAccountsPerProvider",
+        "description": "Allow users to link multiple accounts from the same social provider.\nWhen false, providers already linked to the account are hidden from the available-to-link list.",
+        "tags": [{ "name": "default", "text": "true" }],
+        "type": "boolean",
+        "simplifiedType": "boolean",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "socialProviders",
+        "description": "List of enabled social authentication providers",
+        "tags": [{ "name": "remarks", "text": "`SocialProvider[]`" }],
+        "type": "SocialProvider[]",
+        "simplifiedType": "SocialProvider[]",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "viewPaths",
+        "description": "View path mappings for different authentication views",
+        "tags": [{ "name": "remarks", "text": "`ViewPaths`" }],
+        "type": "ViewPaths",
+        "simplifiedType": "ViewPaths",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "navigate",
+        "description": "Function to navigate to a new path",
+        "tags": [
+          {
+            "name": "param",
+            "text": "options - Navigation options with href and optional replace flag"
+          },
+          {
+            "name": "default",
+            "text": "window.location.href = href (or window.location.replace if replace: true)"
+          },
+          {
+            "name": "example",
+            "text": "// TanStack Router\nnavigate={navigate}\n// Next.js\nnavigate={({href, replace}) => replace ? router.replace(href) : router.push(href)}"
+          }
+        ],
+        "type": "((options: { to: string; replace?: boolean; }) => void) & ((options: { to: string; replace?: boolean; }) => void)",
+        "simplifiedType": "function",
+        "required": true,
+        "deprecated": false
+      },
+      {
+        "name": "Link",
+        "description": "Optional component used to render internal navigation links.\n\nWhen omitted, `AuthLink` renders a native anchor.",
+        "tags": [],
+        "type": "Component<AuthLinkProps>",
+        "simplifiedType": "Component<AuthLinkProps>",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "authClient",
+        "description": "The Solid Better Auth client used by auth context consumers.\nThe auth client to use for the authentication context.",
+        "tags": [
+          { "name": "remarks", "text": "`AuthClient`" },
+          { "name": "remarks", "text": "`AuthClient`" }
+        ],
+        "type": "AuthClient",
+        "simplifiedType": "AuthClient",
+        "required": true,
+        "deprecated": false
+      },
+      {
+        "name": "children",
+        "description": "",
+        "tags": [],
+        "type": "ReactNode",
+        "simplifiedType": "ReactNode",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "queryClient",
+        "description": "TanStack QueryClient to use for your application's queries",
+        "tags": [],
+        "type": "QueryClient",
+        "simplifiedType": "object",
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  }
+]

--- a/apps/docs/.cache/fumadocs-typescript/c59ea7a9c779.json
+++ b/apps/docs/.cache/fumadocs-typescript/c59ea7a9c779.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "reset-password.tsx-ResetPasswordProps",
+    "name": "ResetPasswordProps",
+    "description": "",
+    "entries": [
+      {
+        "name": "className",
+        "description": "",
+        "tags": [],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  }
+]

--- a/apps/docs/.cache/fumadocs-typescript/cb27f341abc5.json
+++ b/apps/docs/.cache/fumadocs-typescript/cb27f341abc5.json
@@ -1,0 +1,54 @@
+[
+  {
+    "id": "sign-up.tsx-SignUpProps",
+    "name": "SignUpProps",
+    "description": "",
+    "entries": [
+      {
+        "name": "className",
+        "description": "",
+        "tags": [],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "socialLayout",
+        "description": "",
+        "tags": [],
+        "type": "SocialLayout",
+        "simplifiedType": "SocialLayout",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "socialPosition",
+        "description": "",
+        "tags": [],
+        "type": "\"top\" | \"bottom\"",
+        "simplifiedType": "\"top\" | \"bottom\"",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "variant",
+        "description": "",
+        "tags": [],
+        "type": "\"default\" | \"secondary\" | \"tertiary\" | \"transparent\"",
+        "simplifiedType": "\"default\" | \"secondary\" | \"tertiary\" | \"transparent\"",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "onSignUpSuccess",
+        "description": "Runs instead of the post-sign-up redirect, but only when the sign-up\ncreated an immediately usable session. Email verification still takes\npriority, and social sign-ups are unaffected.",
+        "tags": [],
+        "type": "(() => void)",
+        "simplifiedType": "function",
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  }
+]

--- a/apps/docs/.cache/fumadocs-typescript/cf16daefb831.json
+++ b/apps/docs/.cache/fumadocs-typescript/cf16daefb831.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "change-email.tsx-ChangeEmailProps",
+    "name": "ChangeEmailProps",
+    "description": "",
+    "entries": [
+      {
+        "name": "className",
+        "description": "",
+        "tags": [],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  }
+]

--- a/apps/docs/.cache/fumadocs-typescript/d473d5e8080d.json
+++ b/apps/docs/.cache/fumadocs-typescript/d473d5e8080d.json
@@ -1,0 +1,27 @@
+[
+  {
+    "id": "forgot-password.tsx-ForgotPasswordProps",
+    "name": "ForgotPasswordProps",
+    "description": "",
+    "entries": [
+      {
+        "name": "className",
+        "description": "",
+        "tags": [],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "variant",
+        "description": "",
+        "tags": [],
+        "type": "\"default\" | \"secondary\" | \"tertiary\" | \"transparent\"",
+        "simplifiedType": "\"default\" | \"secondary\" | \"tertiary\" | \"transparent\"",
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  }
+]

--- a/apps/docs/.cache/fumadocs-typescript/d4ca1b8d7871.json
+++ b/apps/docs/.cache/fumadocs-typescript/d4ca1b8d7871.json
@@ -1,0 +1,27 @@
+[
+  {
+    "id": "change-password.tsx-ChangePasswordSettingsProps",
+    "name": "ChangePasswordSettingsProps",
+    "description": "",
+    "entries": [
+      {
+        "name": "class",
+        "description": "",
+        "tags": [],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "confirmPassword",
+        "description": "",
+        "tags": [],
+        "type": "boolean",
+        "simplifiedType": "boolean",
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  }
+]

--- a/apps/docs/.cache/fumadocs-typescript/eec8cadf0f0f.json
+++ b/apps/docs/.cache/fumadocs-typescript/eec8cadf0f0f.json
@@ -1,0 +1,45 @@
+[
+  {
+    "id": "sign-up.tsx-SignUpProps",
+    "name": "SignUpProps",
+    "description": "",
+    "entries": [
+      {
+        "name": "class",
+        "description": "",
+        "tags": [],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "socialLayout",
+        "description": "",
+        "tags": [],
+        "type": "SocialLayout",
+        "simplifiedType": "SocialLayout",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "socialPosition",
+        "description": "",
+        "tags": [],
+        "type": "\"top\" | \"bottom\"",
+        "simplifiedType": "\"top\" | \"bottom\"",
+        "required": false,
+        "deprecated": false
+      },
+      {
+        "name": "onSignUpSuccess",
+        "description": "Runs instead of the post-sign-up redirect, but only when the sign-up\ncreated an immediately usable session. Email verification still takes\npriority, and social sign-ups are unaffected.",
+        "tags": [],
+        "type": "(() => void)",
+        "simplifiedType": "function",
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  }
+]

--- a/apps/docs/.cache/fumadocs-typescript/f18475b04279.json
+++ b/apps/docs/.cache/fumadocs-typescript/f18475b04279.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "change-password.tsx-ChangePasswordProps",
+    "name": "ChangePasswordProps",
+    "description": "",
+    "entries": [
+      {
+        "name": "className",
+        "description": "",
+        "tags": [],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  }
+]

--- a/apps/docs/.cache/fumadocs-typescript/f54d1cb778c7.json
+++ b/apps/docs/.cache/fumadocs-typescript/f54d1cb778c7.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "verify-email-otp.tsx-VerifyEmailOtpProps",
+    "name": "VerifyEmailOtpProps",
+    "description": "",
+    "entries": [
+      {
+        "name": "class",
+        "description": "",
+        "tags": [],
+        "type": "string",
+        "simplifiedType": "string",
+        "required": false,
+        "deprecated": false
+      }
+    ]
+  }
+]

--- a/apps/docs/src/components/auth/email-otp/email-otp-button.tsx
+++ b/apps/docs/src/components/auth/email-otp/email-otp-button.tsx
@@ -1,6 +1,10 @@
 "use client"
 
-import { type AuthView, authMutationKeys } from "@better-auth-ui/core"
+import {
+  type AuthView,
+  authMutationKeys,
+  getAuthLinkURL
+} from "@better-auth-ui/core"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useIsMutating } from "@tanstack/react-query"
 import { KeyRound, Lock } from "lucide-react"
@@ -20,8 +24,14 @@ export type EmailOtpButtonProps = {
  * @param view - Current auth view. On `"emailOtp"` this links back to password sign-in.
  */
 export function EmailOtpButton({ view }: EmailOtpButtonProps) {
-  const { basePaths, emailAndPassword, localization, viewPaths, Link } =
-    useAuth()
+  const {
+    basePaths,
+    emailAndPassword,
+    localization,
+    redirectTo,
+    viewPaths,
+    Link
+  } = useAuth()
   const { localization: emailOtpLocalization, viewPaths: emailOtpViewPaths } =
     useAuthPlugin(emailOtpPlugin)
 
@@ -41,7 +51,10 @@ export function EmailOtpButton({ view }: EmailOtpButtonProps) {
 
   return (
     <Link
-      href={`${basePaths.auth}/${isEmailOtpView ? viewPaths.auth.signIn : emailOtpViewPaths.auth.emailOtp}`}
+      href={getAuthLinkURL(
+        `${basePaths.auth}/${isEmailOtpView ? viewPaths.auth.signIn : emailOtpViewPaths.auth.emailOtp}`,
+        redirectTo
+      )}
       aria-disabled={isPending || undefined}
       tabIndex={isPending ? -1 : undefined}
       onClick={(event) => {

--- a/apps/docs/src/components/auth/email-otp/forgot-password-otp.tsx
+++ b/apps/docs/src/components/auth/email-otp/forgot-password-otp.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getAuthLinkURL } from "@better-auth-ui/core"
 import {
   type EmailOtpAuthClient,
   useAuth,
@@ -48,6 +49,7 @@ export function ForgotPasswordOtp({ className }: ForgotPasswordOtpProps) {
     localization,
     navigate,
     plugins,
+    redirectTo,
     viewPaths,
     Link
   } = useAuth()
@@ -132,7 +134,10 @@ export function ForgotPasswordOtp({ className }: ForgotPasswordOtpProps) {
           <FieldDescription className="text-center">
             {localization.auth.rememberYourPassword}{" "}
             <Link
-              href={`${basePaths.auth}/${viewPaths.auth.signIn}`}
+              href={getAuthLinkURL(
+                `${basePaths.auth}/${viewPaths.auth.signIn}`,
+                redirectTo
+              )}
               className="underline underline-offset-4"
             >
               {localization.auth.signIn}

--- a/apps/docs/src/components/auth/email-otp/reset-password-otp.tsx
+++ b/apps/docs/src/components/auth/email-otp/reset-password-otp.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getAuthLinkURL } from "@better-auth-ui/core"
 import {
   type EmailOtpAuthClient,
   useAuth,
@@ -62,6 +63,7 @@ export function ResetPasswordOtp({ className }: ResetPasswordOtpProps) {
     emailAndPassword,
     localization,
     navigate,
+    redirectTo,
     viewPaths,
     Link
   } = useAuth()
@@ -319,7 +321,10 @@ export function ResetPasswordOtp({ className }: ResetPasswordOtpProps) {
           <FieldDescription className="text-center">
             {localization.auth.rememberYourPassword}{" "}
             <Link
-              href={`${basePaths.auth}/${viewPaths.auth.signIn}`}
+              href={getAuthLinkURL(
+                `${basePaths.auth}/${viewPaths.auth.signIn}`,
+                redirectTo
+              )}
               className="underline underline-offset-4"
             >
               {localization.auth.signIn}

--- a/apps/docs/src/components/auth/email-otp/verify-email-otp.tsx
+++ b/apps/docs/src/components/auth/email-otp/verify-email-otp.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getAuthLinkURL } from "@better-auth-ui/core"
 import {
   type EmailOtpAuthClient,
   useAuth,
@@ -235,7 +236,10 @@ export function VerifyEmailOtp({ className }: VerifyEmailOtpProps) {
           <FieldDescription className="text-center">
             {localization.auth.alreadyVerifiedYourEmail}{" "}
             <Link
-              href={`${basePaths.auth}/${viewPaths.auth.signIn}`}
+              href={getAuthLinkURL(
+                `${basePaths.auth}/${viewPaths.auth.signIn}`,
+                redirectTo
+              )}
               className="underline underline-offset-4"
             >
               {localization.auth.signIn}

--- a/apps/docs/src/components/auth/forgot-password.tsx
+++ b/apps/docs/src/components/auth/forgot-password.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getViewURL } from "@better-auth-ui/core"
 import {
   useAuth,
   useFetchOptions,
@@ -68,7 +69,11 @@ export function ForgotPassword({ className }: ForgotPasswordProps) {
     const formData = new FormData(e.currentTarget)
     requestPasswordReset({
       email: formData.get("email") as string,
-      redirectTo: `${baseURL}${basePaths.auth}/${viewPaths.auth.resetPassword}`,
+      redirectTo: getViewURL(
+        baseURL,
+        basePaths.auth,
+        viewPaths.auth.resetPassword
+      ),
       fetchOptions
     })
   }

--- a/apps/docs/src/components/auth/reset-link-sent.tsx
+++ b/apps/docs/src/components/auth/reset-link-sent.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getAuthLinkURL } from "@better-auth-ui/core"
 import { useAuth } from "@better-auth-ui/react"
 import { useEffect, useState } from "react"
 
@@ -28,7 +29,7 @@ export type ResetLinkSentProps = {
  * @returns The reset-link-sent card React element
  */
 export function ResetLinkSent({ className }: ResetLinkSentProps) {
-  const { basePaths, localization, viewPaths, Link } = useAuth()
+  const { basePaths, localization, redirectTo, viewPaths, Link } = useAuth()
 
   const isHydrated = useIsHydrated()
   const [email, setEmail] = useState(
@@ -62,7 +63,10 @@ export function ResetLinkSent({ className }: ResetLinkSentProps) {
           <FieldDescription className="text-center">
             {localization.auth.rememberYourPassword}{" "}
             <Link
-              href={`${basePaths.auth}/${viewPaths.auth.signIn}`}
+              href={getAuthLinkURL(
+                `${basePaths.auth}/${viewPaths.auth.signIn}`,
+                redirectTo
+              )}
               className="underline underline-offset-4"
             >
               {localization.auth.signIn}

--- a/apps/docs/src/components/auth/reset-password.tsx
+++ b/apps/docs/src/components/auth/reset-password.tsx
@@ -46,11 +46,15 @@ export function ResetPassword({ className }: ResetPasswordProps) {
     viewPaths,
     Link
   } = useAuth()
+  const signInURL = getAuthLinkURL(
+    `${basePaths.auth}/${viewPaths.auth.signIn}`,
+    redirectTo
+  )
 
   const { mutate: resetPassword, isPending } = useResetPassword(authClient, {
     onSuccess: () => {
       toast.success(localization.auth.passwordResetSuccess)
-      navigate({ to: `${basePaths.auth}/${viewPaths.auth.signIn}` })
+      navigate({ to: signInURL })
     }
   })
 
@@ -69,14 +73,9 @@ export function ResetPassword({ className }: ResetPasswordProps) {
 
     if (!token) {
       toast.error(localization.auth.invalidResetPasswordToken)
-      navigate({ to: `${basePaths.auth}/${viewPaths.auth.signIn}` })
+      navigate({ to: signInURL })
     }
-  }, [
-    basePaths.auth,
-    localization.auth.invalidResetPasswordToken,
-    viewPaths.auth.signIn,
-    navigate
-  ])
+  }, [localization.auth.invalidResetPasswordToken, navigate, signInURL])
 
   function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
     e.preventDefault()
@@ -86,7 +85,7 @@ export function ResetPassword({ className }: ResetPasswordProps) {
 
     if (!token) {
       toast.error(localization.auth.invalidResetPasswordToken)
-      navigate({ to: `${basePaths.auth}/${viewPaths.auth.signIn}` })
+      navigate({ to: signInURL })
       return
     }
 

--- a/apps/docs/src/components/auth/reset-password.tsx
+++ b/apps/docs/src/components/auth/reset-password.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getAuthLinkURL } from "@better-auth-ui/core"
 import { useAuth, useResetPassword } from "@better-auth-ui/react"
 import { Eye, EyeOff } from "lucide-react"
 import { type SyntheticEvent, useEffect, useState } from "react"
@@ -40,8 +41,9 @@ export function ResetPassword({ className }: ResetPasswordProps) {
     basePaths,
     emailAndPassword,
     localization,
-    viewPaths,
     navigate,
+    redirectTo,
+    viewPaths,
     Link
   } = useAuth()
 
@@ -271,7 +273,10 @@ export function ResetPassword({ className }: ResetPasswordProps) {
           <FieldDescription className="text-center">
             {localization.auth.rememberYourPassword}{" "}
             <Link
-              href={`${basePaths.auth}/${viewPaths.auth.signIn}`}
+              href={getAuthLinkURL(
+                `${basePaths.auth}/${viewPaths.auth.signIn}`,
+                redirectTo
+              )}
               className="underline underline-offset-4"
             >
               {localization.auth.signIn}

--- a/apps/docs/src/components/auth/settings/account/change-email.tsx
+++ b/apps/docs/src/components/auth/settings/account/change-email.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getViewURL } from "@better-auth-ui/core"
 import { useAuth, useChangeEmail, useSession } from "@better-auth-ui/react"
 import { type SyntheticEvent, useState } from "react"
 import { toast } from "sonner"
@@ -26,7 +27,7 @@ export type ChangeEmailProps = {
  * @returns A JSX element rendering the change-email card and form
  */
 export function ChangeEmail({ className }: ChangeEmailProps) {
-  const { authClient, baseURL, localization, viewPaths } = useAuth()
+  const { authClient, basePaths, baseURL, localization, viewPaths } = useAuth()
   const { data: session } = useSession(authClient)
 
   const { mutate: changeEmail, isPending } = useChangeEmail(authClient, {
@@ -43,7 +44,11 @@ export function ChangeEmail({ className }: ChangeEmailProps) {
     const formData = new FormData(e.currentTarget)
     changeEmail({
       newEmail: formData.get("email") as string,
-      callbackURL: `${baseURL}/${viewPaths.settings.account}`
+      callbackURL: getViewURL(
+        baseURL,
+        basePaths.settings,
+        viewPaths.settings.account
+      )
     })
   }
 

--- a/apps/docs/src/components/auth/settings/security/change-password.tsx
+++ b/apps/docs/src/components/auth/settings/security/change-password.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getViewURL } from "@better-auth-ui/core"
 import {
   useAuth,
   useChangePassword,
@@ -65,7 +66,8 @@ export function ChangePassword({ className }: ChangePasswordProps) {
 }
 
 function SetPassword({ className }: { className?: string }) {
-  const { authClient, localization, plugins } = useAuth()
+  const { authClient, basePaths, baseURL, localization, plugins, viewPaths } =
+    useAuth()
   const { data: session } = useSession(authClient)
   const { fetchOptions, resetFetchOptions } = useFetchOptions()
   const [sentEmail, setSentEmail] = useState("")
@@ -89,7 +91,15 @@ function SetPassword({ className }: { className?: string }) {
   const handleSetPassword = () => {
     if (!session) return
 
-    requestPasswordReset({ email: session.user.email, fetchOptions })
+    requestPasswordReset({
+      email: session.user.email,
+      redirectTo: getViewURL(
+        baseURL,
+        basePaths.auth,
+        viewPaths.auth.resetPassword
+      ),
+      fetchOptions
+    })
   }
 
   return (

--- a/apps/docs/src/components/auth/sign-up.tsx
+++ b/apps/docs/src/components/auth/sign-up.tsx
@@ -2,6 +2,7 @@
 
 import {
   authMutationKeys,
+  getAuthLinkURL,
   parseAdditionalFieldValue
 } from "@better-auth-ui/core"
 import {
@@ -508,7 +509,10 @@ export function SignUp({
             <FieldDescription className="text-center">
               {localization.auth.alreadyHaveAnAccount}{" "}
               <Link
-                href={`${basePaths.auth}/${viewPaths.auth.signIn}`}
+                href={getAuthLinkURL(
+                  `${basePaths.auth}/${viewPaths.auth.signIn}`,
+                  redirectTo
+                )}
                 className="underline underline-offset-4"
               >
                 {localization.auth.signIn}

--- a/apps/docs/src/components/auth/sign-up.tsx
+++ b/apps/docs/src/components/auth/sign-up.tsx
@@ -101,7 +101,10 @@ export function SignUp({
         if (emailAndPassword?.requireEmailVerification) {
           sessionStorage.setItem("better-auth-ui.verify-email", email)
           navigate({
-            to: `${basePaths.auth}/${viewPaths.auth.verifyEmail}`
+            to: getAuthLinkURL(
+              `${basePaths.auth}/${viewPaths.auth.verifyEmail}`,
+              redirectTo
+            )
           })
         } else if (onSignUpSuccess) {
           onSignUpSuccess()

--- a/examples/next-shadcn-example/src/components/auth/email-otp/email-otp-button.tsx
+++ b/examples/next-shadcn-example/src/components/auth/email-otp/email-otp-button.tsx
@@ -1,6 +1,10 @@
 "use client"
 
-import { type AuthView, authMutationKeys } from "@better-auth-ui/core"
+import {
+  type AuthView,
+  authMutationKeys,
+  getAuthLinkURL
+} from "@better-auth-ui/core"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useIsMutating } from "@tanstack/react-query"
 import { KeyRound, Lock } from "lucide-react"
@@ -20,8 +24,14 @@ export type EmailOtpButtonProps = {
  * @param view - Current auth view. On `"emailOtp"` this links back to password sign-in.
  */
 export function EmailOtpButton({ view }: EmailOtpButtonProps) {
-  const { basePaths, emailAndPassword, localization, viewPaths, Link } =
-    useAuth()
+  const {
+    basePaths,
+    emailAndPassword,
+    localization,
+    redirectTo,
+    viewPaths,
+    Link
+  } = useAuth()
   const { localization: emailOtpLocalization, viewPaths: emailOtpViewPaths } =
     useAuthPlugin(emailOtpPlugin)
 
@@ -41,7 +51,10 @@ export function EmailOtpButton({ view }: EmailOtpButtonProps) {
 
   return (
     <Link
-      href={`${basePaths.auth}/${isEmailOtpView ? viewPaths.auth.signIn : emailOtpViewPaths.auth.emailOtp}`}
+      href={getAuthLinkURL(
+        `${basePaths.auth}/${isEmailOtpView ? viewPaths.auth.signIn : emailOtpViewPaths.auth.emailOtp}`,
+        redirectTo
+      )}
       aria-disabled={isPending || undefined}
       tabIndex={isPending ? -1 : undefined}
       onClick={(event) => {

--- a/examples/next-shadcn-example/src/components/auth/email-otp/forgot-password-otp.tsx
+++ b/examples/next-shadcn-example/src/components/auth/email-otp/forgot-password-otp.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getAuthLinkURL } from "@better-auth-ui/core"
 import {
   type EmailOtpAuthClient,
   useAuth,
@@ -48,6 +49,7 @@ export function ForgotPasswordOtp({ className }: ForgotPasswordOtpProps) {
     localization,
     navigate,
     plugins,
+    redirectTo,
     viewPaths,
     Link
   } = useAuth()
@@ -132,7 +134,10 @@ export function ForgotPasswordOtp({ className }: ForgotPasswordOtpProps) {
           <FieldDescription className="text-center">
             {localization.auth.rememberYourPassword}{" "}
             <Link
-              href={`${basePaths.auth}/${viewPaths.auth.signIn}`}
+              href={getAuthLinkURL(
+                `${basePaths.auth}/${viewPaths.auth.signIn}`,
+                redirectTo
+              )}
               className="underline underline-offset-4"
             >
               {localization.auth.signIn}

--- a/examples/next-shadcn-example/src/components/auth/email-otp/reset-password-otp.tsx
+++ b/examples/next-shadcn-example/src/components/auth/email-otp/reset-password-otp.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getAuthLinkURL } from "@better-auth-ui/core"
 import {
   type EmailOtpAuthClient,
   useAuth,
@@ -62,6 +63,7 @@ export function ResetPasswordOtp({ className }: ResetPasswordOtpProps) {
     emailAndPassword,
     localization,
     navigate,
+    redirectTo,
     viewPaths,
     Link
   } = useAuth()
@@ -319,7 +321,10 @@ export function ResetPasswordOtp({ className }: ResetPasswordOtpProps) {
           <FieldDescription className="text-center">
             {localization.auth.rememberYourPassword}{" "}
             <Link
-              href={`${basePaths.auth}/${viewPaths.auth.signIn}`}
+              href={getAuthLinkURL(
+                `${basePaths.auth}/${viewPaths.auth.signIn}`,
+                redirectTo
+              )}
               className="underline underline-offset-4"
             >
               {localization.auth.signIn}

--- a/examples/next-shadcn-example/src/components/auth/email-otp/verify-email-otp.tsx
+++ b/examples/next-shadcn-example/src/components/auth/email-otp/verify-email-otp.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getAuthLinkURL } from "@better-auth-ui/core"
 import {
   type EmailOtpAuthClient,
   useAuth,
@@ -235,7 +236,10 @@ export function VerifyEmailOtp({ className }: VerifyEmailOtpProps) {
           <FieldDescription className="text-center">
             {localization.auth.alreadyVerifiedYourEmail}{" "}
             <Link
-              href={`${basePaths.auth}/${viewPaths.auth.signIn}`}
+              href={getAuthLinkURL(
+                `${basePaths.auth}/${viewPaths.auth.signIn}`,
+                redirectTo
+              )}
               className="underline underline-offset-4"
             >
               {localization.auth.signIn}

--- a/examples/next-shadcn-example/src/components/auth/forgot-password.tsx
+++ b/examples/next-shadcn-example/src/components/auth/forgot-password.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getViewURL } from "@better-auth-ui/core"
 import {
   useAuth,
   useFetchOptions,
@@ -68,7 +69,11 @@ export function ForgotPassword({ className }: ForgotPasswordProps) {
     const formData = new FormData(e.currentTarget)
     requestPasswordReset({
       email: formData.get("email") as string,
-      redirectTo: `${baseURL}${basePaths.auth}/${viewPaths.auth.resetPassword}`,
+      redirectTo: getViewURL(
+        baseURL,
+        basePaths.auth,
+        viewPaths.auth.resetPassword
+      ),
       fetchOptions
     })
   }

--- a/examples/next-shadcn-example/src/components/auth/reset-link-sent.tsx
+++ b/examples/next-shadcn-example/src/components/auth/reset-link-sent.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getAuthLinkURL } from "@better-auth-ui/core"
 import { useAuth } from "@better-auth-ui/react"
 import { useEffect, useState } from "react"
 
@@ -28,7 +29,7 @@ export type ResetLinkSentProps = {
  * @returns The reset-link-sent card React element
  */
 export function ResetLinkSent({ className }: ResetLinkSentProps) {
-  const { basePaths, localization, viewPaths, Link } = useAuth()
+  const { basePaths, localization, redirectTo, viewPaths, Link } = useAuth()
 
   const isHydrated = useIsHydrated()
   const [email, setEmail] = useState(
@@ -62,7 +63,10 @@ export function ResetLinkSent({ className }: ResetLinkSentProps) {
           <FieldDescription className="text-center">
             {localization.auth.rememberYourPassword}{" "}
             <Link
-              href={`${basePaths.auth}/${viewPaths.auth.signIn}`}
+              href={getAuthLinkURL(
+                `${basePaths.auth}/${viewPaths.auth.signIn}`,
+                redirectTo
+              )}
               className="underline underline-offset-4"
             >
               {localization.auth.signIn}

--- a/examples/next-shadcn-example/src/components/auth/reset-password.tsx
+++ b/examples/next-shadcn-example/src/components/auth/reset-password.tsx
@@ -46,11 +46,15 @@ export function ResetPassword({ className }: ResetPasswordProps) {
     viewPaths,
     Link
   } = useAuth()
+  const signInURL = getAuthLinkURL(
+    `${basePaths.auth}/${viewPaths.auth.signIn}`,
+    redirectTo
+  )
 
   const { mutate: resetPassword, isPending } = useResetPassword(authClient, {
     onSuccess: () => {
       toast.success(localization.auth.passwordResetSuccess)
-      navigate({ to: `${basePaths.auth}/${viewPaths.auth.signIn}` })
+      navigate({ to: signInURL })
     }
   })
 
@@ -69,14 +73,9 @@ export function ResetPassword({ className }: ResetPasswordProps) {
 
     if (!token) {
       toast.error(localization.auth.invalidResetPasswordToken)
-      navigate({ to: `${basePaths.auth}/${viewPaths.auth.signIn}` })
+      navigate({ to: signInURL })
     }
-  }, [
-    basePaths.auth,
-    localization.auth.invalidResetPasswordToken,
-    viewPaths.auth.signIn,
-    navigate
-  ])
+  }, [localization.auth.invalidResetPasswordToken, navigate, signInURL])
 
   function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
     e.preventDefault()
@@ -86,7 +85,7 @@ export function ResetPassword({ className }: ResetPasswordProps) {
 
     if (!token) {
       toast.error(localization.auth.invalidResetPasswordToken)
-      navigate({ to: `${basePaths.auth}/${viewPaths.auth.signIn}` })
+      navigate({ to: signInURL })
       return
     }
 

--- a/examples/next-shadcn-example/src/components/auth/reset-password.tsx
+++ b/examples/next-shadcn-example/src/components/auth/reset-password.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getAuthLinkURL } from "@better-auth-ui/core"
 import { useAuth, useResetPassword } from "@better-auth-ui/react"
 import { Eye, EyeOff } from "lucide-react"
 import { type SyntheticEvent, useEffect, useState } from "react"
@@ -40,8 +41,9 @@ export function ResetPassword({ className }: ResetPasswordProps) {
     basePaths,
     emailAndPassword,
     localization,
-    viewPaths,
     navigate,
+    redirectTo,
+    viewPaths,
     Link
   } = useAuth()
 
@@ -271,7 +273,10 @@ export function ResetPassword({ className }: ResetPasswordProps) {
           <FieldDescription className="text-center">
             {localization.auth.rememberYourPassword}{" "}
             <Link
-              href={`${basePaths.auth}/${viewPaths.auth.signIn}`}
+              href={getAuthLinkURL(
+                `${basePaths.auth}/${viewPaths.auth.signIn}`,
+                redirectTo
+              )}
               className="underline underline-offset-4"
             >
               {localization.auth.signIn}

--- a/examples/next-shadcn-example/src/components/auth/settings/account/change-email.tsx
+++ b/examples/next-shadcn-example/src/components/auth/settings/account/change-email.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getViewURL } from "@better-auth-ui/core"
 import { useAuth, useChangeEmail, useSession } from "@better-auth-ui/react"
 import { type SyntheticEvent, useState } from "react"
 import { toast } from "sonner"
@@ -26,7 +27,7 @@ export type ChangeEmailProps = {
  * @returns A JSX element rendering the change-email card and form
  */
 export function ChangeEmail({ className }: ChangeEmailProps) {
-  const { authClient, baseURL, localization, viewPaths } = useAuth()
+  const { authClient, basePaths, baseURL, localization, viewPaths } = useAuth()
   const { data: session } = useSession(authClient)
 
   const { mutate: changeEmail, isPending } = useChangeEmail(authClient, {
@@ -43,7 +44,11 @@ export function ChangeEmail({ className }: ChangeEmailProps) {
     const formData = new FormData(e.currentTarget)
     changeEmail({
       newEmail: formData.get("email") as string,
-      callbackURL: `${baseURL}/${viewPaths.settings.account}`
+      callbackURL: getViewURL(
+        baseURL,
+        basePaths.settings,
+        viewPaths.settings.account
+      )
     })
   }
 

--- a/examples/next-shadcn-example/src/components/auth/settings/security/change-password.tsx
+++ b/examples/next-shadcn-example/src/components/auth/settings/security/change-password.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getViewURL } from "@better-auth-ui/core"
 import {
   useAuth,
   useChangePassword,
@@ -65,7 +66,8 @@ export function ChangePassword({ className }: ChangePasswordProps) {
 }
 
 function SetPassword({ className }: { className?: string }) {
-  const { authClient, localization, plugins } = useAuth()
+  const { authClient, basePaths, baseURL, localization, plugins, viewPaths } =
+    useAuth()
   const { data: session } = useSession(authClient)
   const { fetchOptions, resetFetchOptions } = useFetchOptions()
   const [sentEmail, setSentEmail] = useState("")
@@ -89,7 +91,15 @@ function SetPassword({ className }: { className?: string }) {
   const handleSetPassword = () => {
     if (!session) return
 
-    requestPasswordReset({ email: session.user.email, fetchOptions })
+    requestPasswordReset({
+      email: session.user.email,
+      redirectTo: getViewURL(
+        baseURL,
+        basePaths.auth,
+        viewPaths.auth.resetPassword
+      ),
+      fetchOptions
+    })
   }
 
   return (

--- a/examples/next-shadcn-example/src/components/auth/sign-up.tsx
+++ b/examples/next-shadcn-example/src/components/auth/sign-up.tsx
@@ -2,6 +2,7 @@
 
 import {
   authMutationKeys,
+  getAuthLinkURL,
   parseAdditionalFieldValue
 } from "@better-auth-ui/core"
 import {
@@ -508,7 +509,10 @@ export function SignUp({
             <FieldDescription className="text-center">
               {localization.auth.alreadyHaveAnAccount}{" "}
               <Link
-                href={`${basePaths.auth}/${viewPaths.auth.signIn}`}
+                href={getAuthLinkURL(
+                  `${basePaths.auth}/${viewPaths.auth.signIn}`,
+                  redirectTo
+                )}
                 className="underline underline-offset-4"
               >
                 {localization.auth.signIn}

--- a/examples/next-shadcn-example/src/components/auth/sign-up.tsx
+++ b/examples/next-shadcn-example/src/components/auth/sign-up.tsx
@@ -101,7 +101,10 @@ export function SignUp({
         if (emailAndPassword?.requireEmailVerification) {
           sessionStorage.setItem("better-auth-ui.verify-email", email)
           navigate({
-            to: `${basePaths.auth}/${viewPaths.auth.verifyEmail}`
+            to: getAuthLinkURL(
+              `${basePaths.auth}/${viewPaths.auth.verifyEmail}`,
+              redirectTo
+            )
           })
         } else if (onSignUpSuccess) {
           onSignUpSuccess()

--- a/examples/start-shadcn-baseui-example/src/components/auth/email-otp/email-otp-button.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/email-otp/email-otp-button.tsx
@@ -1,6 +1,10 @@
 "use client"
 
-import { type AuthView, authMutationKeys } from "@better-auth-ui/core"
+import {
+  type AuthView,
+  authMutationKeys,
+  getAuthLinkURL
+} from "@better-auth-ui/core"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useIsMutating } from "@tanstack/react-query"
 import { KeyRound, Lock } from "lucide-react"
@@ -20,8 +24,14 @@ export type EmailOtpButtonProps = {
  * @param view - Current auth view. On `"emailOtp"` this links back to password sign-in.
  */
 export function EmailOtpButton({ view }: EmailOtpButtonProps) {
-  const { basePaths, emailAndPassword, localization, viewPaths, Link } =
-    useAuth()
+  const {
+    basePaths,
+    emailAndPassword,
+    localization,
+    redirectTo,
+    viewPaths,
+    Link
+  } = useAuth()
   const { localization: emailOtpLocalization, viewPaths: emailOtpViewPaths } =
     useAuthPlugin(emailOtpPlugin)
 
@@ -41,7 +51,10 @@ export function EmailOtpButton({ view }: EmailOtpButtonProps) {
 
   return (
     <Link
-      href={`${basePaths.auth}/${isEmailOtpView ? viewPaths.auth.signIn : emailOtpViewPaths.auth.emailOtp}`}
+      href={getAuthLinkURL(
+        `${basePaths.auth}/${isEmailOtpView ? viewPaths.auth.signIn : emailOtpViewPaths.auth.emailOtp}`,
+        redirectTo
+      )}
       aria-disabled={isPending || undefined}
       tabIndex={isPending ? -1 : undefined}
       onClick={(event) => {

--- a/examples/start-shadcn-baseui-example/src/components/auth/email-otp/forgot-password-otp.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/email-otp/forgot-password-otp.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getAuthLinkURL } from "@better-auth-ui/core"
 import {
   type EmailOtpAuthClient,
   useAuth,
@@ -48,6 +49,7 @@ export function ForgotPasswordOtp({ className }: ForgotPasswordOtpProps) {
     localization,
     navigate,
     plugins,
+    redirectTo,
     viewPaths,
     Link
   } = useAuth()
@@ -132,7 +134,10 @@ export function ForgotPasswordOtp({ className }: ForgotPasswordOtpProps) {
           <FieldDescription className="text-center">
             {localization.auth.rememberYourPassword}{" "}
             <Link
-              href={`${basePaths.auth}/${viewPaths.auth.signIn}`}
+              href={getAuthLinkURL(
+                `${basePaths.auth}/${viewPaths.auth.signIn}`,
+                redirectTo
+              )}
               className="underline underline-offset-4"
             >
               {localization.auth.signIn}

--- a/examples/start-shadcn-baseui-example/src/components/auth/email-otp/reset-password-otp.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/email-otp/reset-password-otp.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getAuthLinkURL } from "@better-auth-ui/core"
 import {
   type EmailOtpAuthClient,
   useAuth,
@@ -62,6 +63,7 @@ export function ResetPasswordOtp({ className }: ResetPasswordOtpProps) {
     emailAndPassword,
     localization,
     navigate,
+    redirectTo,
     viewPaths,
     Link
   } = useAuth()
@@ -319,7 +321,10 @@ export function ResetPasswordOtp({ className }: ResetPasswordOtpProps) {
           <FieldDescription className="text-center">
             {localization.auth.rememberYourPassword}{" "}
             <Link
-              href={`${basePaths.auth}/${viewPaths.auth.signIn}`}
+              href={getAuthLinkURL(
+                `${basePaths.auth}/${viewPaths.auth.signIn}`,
+                redirectTo
+              )}
               className="underline underline-offset-4"
             >
               {localization.auth.signIn}

--- a/examples/start-shadcn-baseui-example/src/components/auth/email-otp/verify-email-otp.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/email-otp/verify-email-otp.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getAuthLinkURL } from "@better-auth-ui/core"
 import {
   type EmailOtpAuthClient,
   useAuth,
@@ -235,7 +236,10 @@ export function VerifyEmailOtp({ className }: VerifyEmailOtpProps) {
           <FieldDescription className="text-center">
             {localization.auth.alreadyVerifiedYourEmail}{" "}
             <Link
-              href={`${basePaths.auth}/${viewPaths.auth.signIn}`}
+              href={getAuthLinkURL(
+                `${basePaths.auth}/${viewPaths.auth.signIn}`,
+                redirectTo
+              )}
               className="underline underline-offset-4"
             >
               {localization.auth.signIn}

--- a/examples/start-shadcn-baseui-example/src/components/auth/forgot-password.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/forgot-password.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getViewURL } from "@better-auth-ui/core"
 import {
   useAuth,
   useFetchOptions,
@@ -68,7 +69,11 @@ export function ForgotPassword({ className }: ForgotPasswordProps) {
     const formData = new FormData(e.currentTarget)
     requestPasswordReset({
       email: formData.get("email") as string,
-      redirectTo: `${baseURL}${basePaths.auth}/${viewPaths.auth.resetPassword}`,
+      redirectTo: getViewURL(
+        baseURL,
+        basePaths.auth,
+        viewPaths.auth.resetPassword
+      ),
       fetchOptions
     })
   }

--- a/examples/start-shadcn-baseui-example/src/components/auth/reset-link-sent.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/reset-link-sent.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getAuthLinkURL } from "@better-auth-ui/core"
 import { useAuth } from "@better-auth-ui/react"
 import { useEffect, useState } from "react"
 
@@ -28,7 +29,7 @@ export type ResetLinkSentProps = {
  * @returns The reset-link-sent card React element
  */
 export function ResetLinkSent({ className }: ResetLinkSentProps) {
-  const { basePaths, localization, viewPaths, Link } = useAuth()
+  const { basePaths, localization, redirectTo, viewPaths, Link } = useAuth()
 
   const isHydrated = useIsHydrated()
   const [email, setEmail] = useState(
@@ -62,7 +63,10 @@ export function ResetLinkSent({ className }: ResetLinkSentProps) {
           <FieldDescription className="text-center">
             {localization.auth.rememberYourPassword}{" "}
             <Link
-              href={`${basePaths.auth}/${viewPaths.auth.signIn}`}
+              href={getAuthLinkURL(
+                `${basePaths.auth}/${viewPaths.auth.signIn}`,
+                redirectTo
+              )}
               className="underline underline-offset-4"
             >
               {localization.auth.signIn}

--- a/examples/start-shadcn-baseui-example/src/components/auth/reset-password.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/reset-password.tsx
@@ -46,11 +46,15 @@ export function ResetPassword({ className }: ResetPasswordProps) {
     viewPaths,
     Link
   } = useAuth()
+  const signInURL = getAuthLinkURL(
+    `${basePaths.auth}/${viewPaths.auth.signIn}`,
+    redirectTo
+  )
 
   const { mutate: resetPassword, isPending } = useResetPassword(authClient, {
     onSuccess: () => {
       toast.success(localization.auth.passwordResetSuccess)
-      navigate({ to: `${basePaths.auth}/${viewPaths.auth.signIn}` })
+      navigate({ to: signInURL })
     }
   })
 
@@ -69,14 +73,9 @@ export function ResetPassword({ className }: ResetPasswordProps) {
 
     if (!token) {
       toast.error(localization.auth.invalidResetPasswordToken)
-      navigate({ to: `${basePaths.auth}/${viewPaths.auth.signIn}` })
+      navigate({ to: signInURL })
     }
-  }, [
-    basePaths.auth,
-    localization.auth.invalidResetPasswordToken,
-    viewPaths.auth.signIn,
-    navigate
-  ])
+  }, [localization.auth.invalidResetPasswordToken, navigate, signInURL])
 
   function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
     e.preventDefault()
@@ -86,7 +85,7 @@ export function ResetPassword({ className }: ResetPasswordProps) {
 
     if (!token) {
       toast.error(localization.auth.invalidResetPasswordToken)
-      navigate({ to: `${basePaths.auth}/${viewPaths.auth.signIn}` })
+      navigate({ to: signInURL })
       return
     }
 

--- a/examples/start-shadcn-baseui-example/src/components/auth/reset-password.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/reset-password.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getAuthLinkURL } from "@better-auth-ui/core"
 import { useAuth, useResetPassword } from "@better-auth-ui/react"
 import { Eye, EyeOff } from "lucide-react"
 import { type SyntheticEvent, useEffect, useState } from "react"
@@ -40,8 +41,9 @@ export function ResetPassword({ className }: ResetPasswordProps) {
     basePaths,
     emailAndPassword,
     localization,
-    viewPaths,
     navigate,
+    redirectTo,
+    viewPaths,
     Link
   } = useAuth()
 
@@ -271,7 +273,10 @@ export function ResetPassword({ className }: ResetPasswordProps) {
           <FieldDescription className="text-center">
             {localization.auth.rememberYourPassword}{" "}
             <Link
-              href={`${basePaths.auth}/${viewPaths.auth.signIn}`}
+              href={getAuthLinkURL(
+                `${basePaths.auth}/${viewPaths.auth.signIn}`,
+                redirectTo
+              )}
               className="underline underline-offset-4"
             >
               {localization.auth.signIn}

--- a/examples/start-shadcn-baseui-example/src/components/auth/settings/account/change-email.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/settings/account/change-email.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getViewURL } from "@better-auth-ui/core"
 import { useAuth, useChangeEmail, useSession } from "@better-auth-ui/react"
 import { type SyntheticEvent, useState } from "react"
 import { toast } from "sonner"
@@ -26,7 +27,7 @@ export type ChangeEmailProps = {
  * @returns A JSX element rendering the change-email card and form
  */
 export function ChangeEmail({ className }: ChangeEmailProps) {
-  const { authClient, baseURL, localization, viewPaths } = useAuth()
+  const { authClient, basePaths, baseURL, localization, viewPaths } = useAuth()
   const { data: session } = useSession(authClient)
 
   const { mutate: changeEmail, isPending } = useChangeEmail(authClient, {
@@ -43,7 +44,11 @@ export function ChangeEmail({ className }: ChangeEmailProps) {
     const formData = new FormData(e.currentTarget)
     changeEmail({
       newEmail: formData.get("email") as string,
-      callbackURL: `${baseURL}/${viewPaths.settings.account}`
+      callbackURL: getViewURL(
+        baseURL,
+        basePaths.settings,
+        viewPaths.settings.account
+      )
     })
   }
 

--- a/examples/start-shadcn-baseui-example/src/components/auth/settings/security/change-password.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/settings/security/change-password.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getViewURL } from "@better-auth-ui/core"
 import {
   useAuth,
   useChangePassword,
@@ -65,7 +66,8 @@ export function ChangePassword({ className }: ChangePasswordProps) {
 }
 
 function SetPassword({ className }: { className?: string }) {
-  const { authClient, localization, plugins } = useAuth()
+  const { authClient, basePaths, baseURL, localization, plugins, viewPaths } =
+    useAuth()
   const { data: session } = useSession(authClient)
   const { fetchOptions, resetFetchOptions } = useFetchOptions()
   const [sentEmail, setSentEmail] = useState("")
@@ -89,7 +91,15 @@ function SetPassword({ className }: { className?: string }) {
   const handleSetPassword = () => {
     if (!session) return
 
-    requestPasswordReset({ email: session.user.email, fetchOptions })
+    requestPasswordReset({
+      email: session.user.email,
+      redirectTo: getViewURL(
+        baseURL,
+        basePaths.auth,
+        viewPaths.auth.resetPassword
+      ),
+      fetchOptions
+    })
   }
 
   return (

--- a/examples/start-shadcn-baseui-example/src/components/auth/sign-up.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/sign-up.tsx
@@ -2,6 +2,7 @@
 
 import {
   authMutationKeys,
+  getAuthLinkURL,
   parseAdditionalFieldValue
 } from "@better-auth-ui/core"
 import {
@@ -508,7 +509,10 @@ export function SignUp({
             <FieldDescription className="text-center">
               {localization.auth.alreadyHaveAnAccount}{" "}
               <Link
-                href={`${basePaths.auth}/${viewPaths.auth.signIn}`}
+                href={getAuthLinkURL(
+                  `${basePaths.auth}/${viewPaths.auth.signIn}`,
+                  redirectTo
+                )}
                 className="underline underline-offset-4"
               >
                 {localization.auth.signIn}

--- a/examples/start-shadcn-baseui-example/src/components/auth/sign-up.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/sign-up.tsx
@@ -101,7 +101,10 @@ export function SignUp({
         if (emailAndPassword?.requireEmailVerification) {
           sessionStorage.setItem("better-auth-ui.verify-email", email)
           navigate({
-            to: `${basePaths.auth}/${viewPaths.auth.verifyEmail}`
+            to: getAuthLinkURL(
+              `${basePaths.auth}/${viewPaths.auth.verifyEmail}`,
+              redirectTo
+            )
           })
         } else if (onSignUpSuccess) {
           onSignUpSuccess()

--- a/examples/start-shadcn-example/scripts/sync-consumers.sh
+++ b/examples/start-shadcn-example/scripts/sync-consumers.sh
@@ -36,6 +36,7 @@ BASE_UI_OVERRIDES=(
   components/auth/api-key/create-api-key-dialog.tsx
   components/auth/organization/invite-member-dialog.tsx
   components/auth/phone-number/remove-phone-number-dialog.tsx
+  components/auth/theme/theme-toggle-item.tsx
 )
 
 OVERRIDE_BACKUP="$(mktemp -d)"

--- a/examples/start-shadcn-example/src/components/auth/email-otp/email-otp-button.tsx
+++ b/examples/start-shadcn-example/src/components/auth/email-otp/email-otp-button.tsx
@@ -1,6 +1,10 @@
 "use client"
 
-import { type AuthView, authMutationKeys } from "@better-auth-ui/core"
+import {
+  type AuthView,
+  authMutationKeys,
+  getAuthLinkURL
+} from "@better-auth-ui/core"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useIsMutating } from "@tanstack/react-query"
 import { KeyRound, Lock } from "lucide-react"
@@ -20,8 +24,14 @@ export type EmailOtpButtonProps = {
  * @param view - Current auth view. On `"emailOtp"` this links back to password sign-in.
  */
 export function EmailOtpButton({ view }: EmailOtpButtonProps) {
-  const { basePaths, emailAndPassword, localization, viewPaths, Link } =
-    useAuth()
+  const {
+    basePaths,
+    emailAndPassword,
+    localization,
+    redirectTo,
+    viewPaths,
+    Link
+  } = useAuth()
   const { localization: emailOtpLocalization, viewPaths: emailOtpViewPaths } =
     useAuthPlugin(emailOtpPlugin)
 
@@ -41,7 +51,10 @@ export function EmailOtpButton({ view }: EmailOtpButtonProps) {
 
   return (
     <Link
-      href={`${basePaths.auth}/${isEmailOtpView ? viewPaths.auth.signIn : emailOtpViewPaths.auth.emailOtp}`}
+      href={getAuthLinkURL(
+        `${basePaths.auth}/${isEmailOtpView ? viewPaths.auth.signIn : emailOtpViewPaths.auth.emailOtp}`,
+        redirectTo
+      )}
       aria-disabled={isPending || undefined}
       tabIndex={isPending ? -1 : undefined}
       onClick={(event) => {

--- a/examples/start-shadcn-example/src/components/auth/email-otp/forgot-password-otp.tsx
+++ b/examples/start-shadcn-example/src/components/auth/email-otp/forgot-password-otp.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getAuthLinkURL } from "@better-auth-ui/core"
 import {
   type EmailOtpAuthClient,
   useAuth,
@@ -48,6 +49,7 @@ export function ForgotPasswordOtp({ className }: ForgotPasswordOtpProps) {
     localization,
     navigate,
     plugins,
+    redirectTo,
     viewPaths,
     Link
   } = useAuth()
@@ -132,7 +134,10 @@ export function ForgotPasswordOtp({ className }: ForgotPasswordOtpProps) {
           <FieldDescription className="text-center">
             {localization.auth.rememberYourPassword}{" "}
             <Link
-              href={`${basePaths.auth}/${viewPaths.auth.signIn}`}
+              href={getAuthLinkURL(
+                `${basePaths.auth}/${viewPaths.auth.signIn}`,
+                redirectTo
+              )}
               className="underline underline-offset-4"
             >
               {localization.auth.signIn}

--- a/examples/start-shadcn-example/src/components/auth/email-otp/reset-password-otp.tsx
+++ b/examples/start-shadcn-example/src/components/auth/email-otp/reset-password-otp.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getAuthLinkURL } from "@better-auth-ui/core"
 import {
   type EmailOtpAuthClient,
   useAuth,
@@ -62,6 +63,7 @@ export function ResetPasswordOtp({ className }: ResetPasswordOtpProps) {
     emailAndPassword,
     localization,
     navigate,
+    redirectTo,
     viewPaths,
     Link
   } = useAuth()
@@ -319,7 +321,10 @@ export function ResetPasswordOtp({ className }: ResetPasswordOtpProps) {
           <FieldDescription className="text-center">
             {localization.auth.rememberYourPassword}{" "}
             <Link
-              href={`${basePaths.auth}/${viewPaths.auth.signIn}`}
+              href={getAuthLinkURL(
+                `${basePaths.auth}/${viewPaths.auth.signIn}`,
+                redirectTo
+              )}
               className="underline underline-offset-4"
             >
               {localization.auth.signIn}

--- a/examples/start-shadcn-example/src/components/auth/email-otp/verify-email-otp.tsx
+++ b/examples/start-shadcn-example/src/components/auth/email-otp/verify-email-otp.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getAuthLinkURL } from "@better-auth-ui/core"
 import {
   type EmailOtpAuthClient,
   useAuth,
@@ -235,7 +236,10 @@ export function VerifyEmailOtp({ className }: VerifyEmailOtpProps) {
           <FieldDescription className="text-center">
             {localization.auth.alreadyVerifiedYourEmail}{" "}
             <Link
-              href={`${basePaths.auth}/${viewPaths.auth.signIn}`}
+              href={getAuthLinkURL(
+                `${basePaths.auth}/${viewPaths.auth.signIn}`,
+                redirectTo
+              )}
               className="underline underline-offset-4"
             >
               {localization.auth.signIn}

--- a/examples/start-shadcn-example/src/components/auth/forgot-password.tsx
+++ b/examples/start-shadcn-example/src/components/auth/forgot-password.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getViewURL } from "@better-auth-ui/core"
 import {
   useAuth,
   useFetchOptions,
@@ -68,7 +69,11 @@ export function ForgotPassword({ className }: ForgotPasswordProps) {
     const formData = new FormData(e.currentTarget)
     requestPasswordReset({
       email: formData.get("email") as string,
-      redirectTo: `${baseURL}${basePaths.auth}/${viewPaths.auth.resetPassword}`,
+      redirectTo: getViewURL(
+        baseURL,
+        basePaths.auth,
+        viewPaths.auth.resetPassword
+      ),
       fetchOptions
     })
   }

--- a/examples/start-shadcn-example/src/components/auth/reset-link-sent.tsx
+++ b/examples/start-shadcn-example/src/components/auth/reset-link-sent.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getAuthLinkURL } from "@better-auth-ui/core"
 import { useAuth } from "@better-auth-ui/react"
 import { useEffect, useState } from "react"
 
@@ -28,7 +29,7 @@ export type ResetLinkSentProps = {
  * @returns The reset-link-sent card React element
  */
 export function ResetLinkSent({ className }: ResetLinkSentProps) {
-  const { basePaths, localization, viewPaths, Link } = useAuth()
+  const { basePaths, localization, redirectTo, viewPaths, Link } = useAuth()
 
   const isHydrated = useIsHydrated()
   const [email, setEmail] = useState(
@@ -62,7 +63,10 @@ export function ResetLinkSent({ className }: ResetLinkSentProps) {
           <FieldDescription className="text-center">
             {localization.auth.rememberYourPassword}{" "}
             <Link
-              href={`${basePaths.auth}/${viewPaths.auth.signIn}`}
+              href={getAuthLinkURL(
+                `${basePaths.auth}/${viewPaths.auth.signIn}`,
+                redirectTo
+              )}
               className="underline underline-offset-4"
             >
               {localization.auth.signIn}

--- a/examples/start-shadcn-example/src/components/auth/reset-password.tsx
+++ b/examples/start-shadcn-example/src/components/auth/reset-password.tsx
@@ -46,11 +46,15 @@ export function ResetPassword({ className }: ResetPasswordProps) {
     viewPaths,
     Link
   } = useAuth()
+  const signInURL = getAuthLinkURL(
+    `${basePaths.auth}/${viewPaths.auth.signIn}`,
+    redirectTo
+  )
 
   const { mutate: resetPassword, isPending } = useResetPassword(authClient, {
     onSuccess: () => {
       toast.success(localization.auth.passwordResetSuccess)
-      navigate({ to: `${basePaths.auth}/${viewPaths.auth.signIn}` })
+      navigate({ to: signInURL })
     }
   })
 
@@ -69,14 +73,9 @@ export function ResetPassword({ className }: ResetPasswordProps) {
 
     if (!token) {
       toast.error(localization.auth.invalidResetPasswordToken)
-      navigate({ to: `${basePaths.auth}/${viewPaths.auth.signIn}` })
+      navigate({ to: signInURL })
     }
-  }, [
-    basePaths.auth,
-    localization.auth.invalidResetPasswordToken,
-    viewPaths.auth.signIn,
-    navigate
-  ])
+  }, [localization.auth.invalidResetPasswordToken, navigate, signInURL])
 
   function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
     e.preventDefault()
@@ -86,7 +85,7 @@ export function ResetPassword({ className }: ResetPasswordProps) {
 
     if (!token) {
       toast.error(localization.auth.invalidResetPasswordToken)
-      navigate({ to: `${basePaths.auth}/${viewPaths.auth.signIn}` })
+      navigate({ to: signInURL })
       return
     }
 

--- a/examples/start-shadcn-example/src/components/auth/reset-password.tsx
+++ b/examples/start-shadcn-example/src/components/auth/reset-password.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getAuthLinkURL } from "@better-auth-ui/core"
 import { useAuth, useResetPassword } from "@better-auth-ui/react"
 import { Eye, EyeOff } from "lucide-react"
 import { type SyntheticEvent, useEffect, useState } from "react"
@@ -40,8 +41,9 @@ export function ResetPassword({ className }: ResetPasswordProps) {
     basePaths,
     emailAndPassword,
     localization,
-    viewPaths,
     navigate,
+    redirectTo,
+    viewPaths,
     Link
   } = useAuth()
 
@@ -271,7 +273,10 @@ export function ResetPassword({ className }: ResetPasswordProps) {
           <FieldDescription className="text-center">
             {localization.auth.rememberYourPassword}{" "}
             <Link
-              href={`${basePaths.auth}/${viewPaths.auth.signIn}`}
+              href={getAuthLinkURL(
+                `${basePaths.auth}/${viewPaths.auth.signIn}`,
+                redirectTo
+              )}
               className="underline underline-offset-4"
             >
               {localization.auth.signIn}

--- a/examples/start-shadcn-example/src/components/auth/settings/account/change-email.tsx
+++ b/examples/start-shadcn-example/src/components/auth/settings/account/change-email.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getViewURL } from "@better-auth-ui/core"
 import { useAuth, useChangeEmail, useSession } from "@better-auth-ui/react"
 import { type SyntheticEvent, useState } from "react"
 import { toast } from "sonner"
@@ -26,7 +27,7 @@ export type ChangeEmailProps = {
  * @returns A JSX element rendering the change-email card and form
  */
 export function ChangeEmail({ className }: ChangeEmailProps) {
-  const { authClient, baseURL, localization, viewPaths } = useAuth()
+  const { authClient, basePaths, baseURL, localization, viewPaths } = useAuth()
   const { data: session } = useSession(authClient)
 
   const { mutate: changeEmail, isPending } = useChangeEmail(authClient, {
@@ -43,7 +44,11 @@ export function ChangeEmail({ className }: ChangeEmailProps) {
     const formData = new FormData(e.currentTarget)
     changeEmail({
       newEmail: formData.get("email") as string,
-      callbackURL: `${baseURL}/${viewPaths.settings.account}`
+      callbackURL: getViewURL(
+        baseURL,
+        basePaths.settings,
+        viewPaths.settings.account
+      )
     })
   }
 

--- a/examples/start-shadcn-example/src/components/auth/settings/security/change-password.tsx
+++ b/examples/start-shadcn-example/src/components/auth/settings/security/change-password.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getViewURL } from "@better-auth-ui/core"
 import {
   useAuth,
   useChangePassword,
@@ -65,7 +66,8 @@ export function ChangePassword({ className }: ChangePasswordProps) {
 }
 
 function SetPassword({ className }: { className?: string }) {
-  const { authClient, localization, plugins } = useAuth()
+  const { authClient, basePaths, baseURL, localization, plugins, viewPaths } =
+    useAuth()
   const { data: session } = useSession(authClient)
   const { fetchOptions, resetFetchOptions } = useFetchOptions()
   const [sentEmail, setSentEmail] = useState("")
@@ -89,7 +91,15 @@ function SetPassword({ className }: { className?: string }) {
   const handleSetPassword = () => {
     if (!session) return
 
-    requestPasswordReset({ email: session.user.email, fetchOptions })
+    requestPasswordReset({
+      email: session.user.email,
+      redirectTo: getViewURL(
+        baseURL,
+        basePaths.auth,
+        viewPaths.auth.resetPassword
+      ),
+      fetchOptions
+    })
   }
 
   return (

--- a/examples/start-shadcn-example/src/components/auth/sign-up.tsx
+++ b/examples/start-shadcn-example/src/components/auth/sign-up.tsx
@@ -2,6 +2,7 @@
 
 import {
   authMutationKeys,
+  getAuthLinkURL,
   parseAdditionalFieldValue
 } from "@better-auth-ui/core"
 import {
@@ -508,7 +509,10 @@ export function SignUp({
             <FieldDescription className="text-center">
               {localization.auth.alreadyHaveAnAccount}{" "}
               <Link
-                href={`${basePaths.auth}/${viewPaths.auth.signIn}`}
+                href={getAuthLinkURL(
+                  `${basePaths.auth}/${viewPaths.auth.signIn}`,
+                  redirectTo
+                )}
                 className="underline underline-offset-4"
               >
                 {localization.auth.signIn}

--- a/examples/start-shadcn-example/src/components/auth/sign-up.tsx
+++ b/examples/start-shadcn-example/src/components/auth/sign-up.tsx
@@ -101,7 +101,10 @@ export function SignUp({
         if (emailAndPassword?.requireEmailVerification) {
           sessionStorage.setItem("better-auth-ui.verify-email", email)
           navigate({
-            to: `${basePaths.auth}/${viewPaths.auth.verifyEmail}`
+            to: getAuthLinkURL(
+              `${basePaths.auth}/${viewPaths.auth.verifyEmail}`,
+              redirectTo
+            )
           })
         } else if (onSignUpSuccess) {
           onSignUpSuccess()

--- a/examples/start-solid-zaidan-example/src/components/auth/email-otp/email-otp-button.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/email-otp/email-otp-button.tsx
@@ -1,4 +1,4 @@
-import type { AuthView } from "@better-auth-ui/core"
+import { type AuthView, getAuthLinkURL } from "@better-auth-ui/core"
 import { AuthLink, useAuth, useAuthPlugin } from "@better-auth-ui/solid"
 import { KeyRound, Lock } from "lucide-solid"
 import { Show } from "solid-js"
@@ -28,11 +28,14 @@ export function EmailOtpButton(props: EmailOtpButtonProps) {
     <Show when={isVisible()}>
       <AuthLink
         class={cn(buttonVariants({ variant: "outline" }), "w-full")}
-        href={`${auth.basePaths.auth}/${
-          isEmailOtpView()
-            ? auth.viewPaths.auth.signIn
-            : (emailOtpViewPaths.auth.emailOtp as string)
-        }`}
+        href={getAuthLinkURL(
+          `${auth.basePaths.auth}/${
+            isEmailOtpView()
+              ? auth.viewPaths.auth.signIn
+              : (emailOtpViewPaths.auth.emailOtp as string)
+          }`,
+          auth.redirectTo
+        )}
       >
         <Show fallback={<KeyRound />} when={isEmailOtpView()}>
           <Lock />

--- a/examples/start-solid-zaidan-example/src/components/auth/email-otp/email-otp-button.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/email-otp/email-otp-button.tsx
@@ -1,6 +1,5 @@
 import type { AuthView } from "@better-auth-ui/core"
-import { useAuth, useAuthPlugin } from "@better-auth-ui/solid"
-import { Link } from "@tanstack/solid-router"
+import { AuthLink, useAuth, useAuthPlugin } from "@better-auth-ui/solid"
 import { KeyRound, Lock } from "lucide-solid"
 import { Show } from "solid-js"
 
@@ -27,14 +26,13 @@ export function EmailOtpButton(props: EmailOtpButtonProps) {
 
   return (
     <Show when={isVisible()}>
-      <Link
+      <AuthLink
         class={cn(buttonVariants({ variant: "outline" }), "w-full")}
-        params={{
-          path: isEmailOtpView()
+        href={`${auth.basePaths.auth}/${
+          isEmailOtpView()
             ? auth.viewPaths.auth.signIn
             : (emailOtpViewPaths.auth.emailOtp as string)
-        }}
-        to="/auth/$path"
+        }`}
       >
         <Show fallback={<KeyRound />} when={isEmailOtpView()}>
           <Lock />
@@ -46,7 +44,7 @@ export function EmailOtpButton(props: EmailOtpButtonProps) {
             ? auth.localization.auth.password
             : emailOtpLocalization.emailOtp
         )}
-      </Link>
+      </AuthLink>
     </Show>
   )
 }

--- a/examples/start-solid-zaidan-example/src/components/auth/email-otp/forgot-password-otp.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/email-otp/forgot-password-otp.tsx
@@ -1,3 +1,4 @@
+import { getAuthLinkURL } from "@better-auth-ui/core"
 import {
   AuthLink,
   type EmailOtpAuthClient,
@@ -135,7 +136,10 @@ export function ForgotPasswordOtp(props: ForgotPasswordOtpProps) {
           {auth.localization.auth.rememberYourPassword}{" "}
           <AuthLink
             class="underline underline-offset-4"
-            href={`${auth.basePaths.auth}/${auth.viewPaths.auth.signIn}`}
+            href={getAuthLinkURL(
+              `${auth.basePaths.auth}/${auth.viewPaths.auth.signIn}`,
+              auth.redirectTo
+            )}
           >
             {auth.localization.auth.signIn}
           </AuthLink>

--- a/examples/start-solid-zaidan-example/src/components/auth/email-otp/forgot-password-otp.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/email-otp/forgot-password-otp.tsx
@@ -1,4 +1,5 @@
 import {
+  AuthLink,
   type EmailOtpAuthClient,
   requestPasswordResetOtpOptions,
   useAuth,
@@ -6,7 +7,6 @@ import {
   useFetchOptions
 } from "@better-auth-ui/solid"
 import { createMutation } from "@tanstack/solid-query"
-import { Link } from "@tanstack/solid-router"
 import { createSignal, Show } from "solid-js"
 
 import { Button } from "@/components/ui/button"
@@ -133,13 +133,12 @@ export function ForgotPasswordOtp(props: ForgotPasswordOtpProps) {
       <CardFooter class="justify-center">
         <p class="text-sm text-muted-foreground">
           {auth.localization.auth.rememberYourPassword}{" "}
-          <Link
+          <AuthLink
             class="underline underline-offset-4"
-            params={{ path: auth.viewPaths.auth.signIn }}
-            to="/auth/$path"
+            href={`${auth.basePaths.auth}/${auth.viewPaths.auth.signIn}`}
           >
             {auth.localization.auth.signIn}
-          </Link>
+          </AuthLink>
         </p>
       </CardFooter>
     </Card>

--- a/examples/start-solid-zaidan-example/src/components/auth/email-otp/reset-password-otp.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/email-otp/reset-password-otp.tsx
@@ -1,11 +1,11 @@
 import {
+  AuthLink,
   type EmailOtpAuthClient,
   resetPasswordOtpOptions,
   useAuth,
   useAuthPlugin
 } from "@better-auth-ui/solid"
 import { createMutation } from "@tanstack/solid-query"
-import { Link } from "@tanstack/solid-router"
 import { createSignal, Show } from "solid-js"
 import { toast } from "solid-sonner"
 
@@ -257,13 +257,12 @@ export function ResetPasswordOtp(props: ResetPasswordOtpProps) {
       <CardFooter class="justify-center">
         <p class="text-sm text-muted-foreground">
           {auth.localization.auth.rememberYourPassword}{" "}
-          <Link
+          <AuthLink
             class="underline underline-offset-4"
-            params={{ path: auth.viewPaths.auth.signIn }}
-            to="/auth/$path"
+            href={`${auth.basePaths.auth}/${auth.viewPaths.auth.signIn}`}
           >
             {auth.localization.auth.signIn}
-          </Link>
+          </AuthLink>
         </p>
       </CardFooter>
     </Card>

--- a/examples/start-solid-zaidan-example/src/components/auth/email-otp/reset-password-otp.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/email-otp/reset-password-otp.tsx
@@ -1,3 +1,4 @@
+import { getAuthLinkURL } from "@better-auth-ui/core"
 import {
   AuthLink,
   type EmailOtpAuthClient,
@@ -259,7 +260,10 @@ export function ResetPasswordOtp(props: ResetPasswordOtpProps) {
           {auth.localization.auth.rememberYourPassword}{" "}
           <AuthLink
             class="underline underline-offset-4"
-            href={`${auth.basePaths.auth}/${auth.viewPaths.auth.signIn}`}
+            href={getAuthLinkURL(
+              `${auth.basePaths.auth}/${auth.viewPaths.auth.signIn}`,
+              auth.redirectTo
+            )}
           >
             {auth.localization.auth.signIn}
           </AuthLink>

--- a/examples/start-solid-zaidan-example/src/components/auth/email-otp/verify-email-otp.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/email-otp/verify-email-otp.tsx
@@ -1,4 +1,5 @@
 import {
+  AuthLink,
   type EmailOtpAuthClient,
   sendVerificationOtpOptions,
   useAuth,
@@ -6,7 +7,6 @@ import {
   verifyEmailOtpOptions
 } from "@better-auth-ui/solid"
 import { createMutation } from "@tanstack/solid-query"
-import { Link } from "@tanstack/solid-router"
 import { createSignal, Show } from "solid-js"
 import { toast } from "solid-sonner"
 
@@ -226,13 +226,12 @@ export function VerifyEmailOtp(props: VerifyEmailOtpProps) {
       <CardFooter class="justify-center">
         <p class="text-sm text-muted-foreground">
           {auth.localization.auth.alreadyVerifiedYourEmail}{" "}
-          <Link
+          <AuthLink
             class="underline underline-offset-4"
-            params={{ path: auth.viewPaths.auth.signIn }}
-            to="/auth/$path"
+            href={`${auth.basePaths.auth}/${auth.viewPaths.auth.signIn}`}
           >
             {auth.localization.auth.signIn}
-          </Link>
+          </AuthLink>
         </p>
       </CardFooter>
     </Card>

--- a/examples/start-solid-zaidan-example/src/components/auth/email-otp/verify-email-otp.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/email-otp/verify-email-otp.tsx
@@ -1,3 +1,4 @@
+import { getAuthLinkURL } from "@better-auth-ui/core"
 import {
   AuthLink,
   type EmailOtpAuthClient,
@@ -228,7 +229,10 @@ export function VerifyEmailOtp(props: VerifyEmailOtpProps) {
           {auth.localization.auth.alreadyVerifiedYourEmail}{" "}
           <AuthLink
             class="underline underline-offset-4"
-            href={`${auth.basePaths.auth}/${auth.viewPaths.auth.signIn}`}
+            href={getAuthLinkURL(
+              `${auth.basePaths.auth}/${auth.viewPaths.auth.signIn}`,
+              auth.redirectTo
+            )}
           >
             {auth.localization.auth.signIn}
           </AuthLink>

--- a/examples/start-solid-zaidan-example/src/components/auth/forgot-password.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/forgot-password.tsx
@@ -1,11 +1,12 @@
+import { getViewURL } from "@better-auth-ui/core"
 import {
+  AuthLink,
   requestPasswordResetOptions,
   useAuth,
   useFetchOptions
 } from "@better-auth-ui/solid"
 import type { AuthPlugin } from "@better-auth-ui/solid/plugins"
 import { createMutation } from "@tanstack/solid-query"
-import { Link } from "@tanstack/solid-router"
 import { createSignal, Show } from "solid-js"
 import { RESET_LINK_SENT_STORAGE_KEY } from "@/components/auth/reset-link-sent"
 import { Alert, AlertDescription } from "@/components/ui/alert"
@@ -48,7 +49,13 @@ export function ForgotPassword(props: ForgotPasswordProps) {
     requestReset.mutate({
       email: email(),
       fetchOptions: fetchOptions(),
-      redirectTo: props.redirectTo
+      redirectTo:
+        props.redirectTo ??
+        getViewURL(
+          auth.baseURL,
+          auth.basePaths.auth,
+          auth.viewPaths.auth.resetPassword
+        )
     } as Parameters<typeof requestReset.mutate>[0])
   }
 
@@ -110,13 +117,12 @@ export function ForgotPassword(props: ForgotPasswordProps) {
         <div class="mt-4 flex w-full flex-col items-center gap-3">
           <p class="text-center text-sm text-muted-foreground">
             {auth.localization.auth.rememberYourPassword}{" "}
-            <Link
+            <AuthLink
               class="underline underline-offset-4"
-              params={{ path: auth.viewPaths.auth.signIn }}
-              to="/auth/$path"
+              href={`${auth.basePaths.auth}/${auth.viewPaths.auth.signIn}`}
             >
               {auth.localization.auth.signIn}
-            </Link>
+            </AuthLink>
           </p>
         </div>
       </CardContent>

--- a/examples/start-solid-zaidan-example/src/components/auth/magic-link-button.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/magic-link-button.tsx
@@ -4,9 +4,8 @@ import {
   type MagicLinkLocalization,
   magicLinkLocalization
 } from "@better-auth-ui/core/plugins"
-import { useAuth } from "@better-auth-ui/solid"
+import { AuthLink, useAuth } from "@better-auth-ui/solid"
 import { useIsMutating } from "@tanstack/solid-query"
-import { Link } from "@tanstack/solid-router"
 import { Lock, Mail } from "lucide-solid"
 import { buttonVariants } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
@@ -40,7 +39,7 @@ export function MagicLinkButton(props: MagicLinkButtonProps) {
   if (isMagicLinkView() && !auth.emailAndPassword?.enabled) return null
 
   return (
-    <Link
+    <AuthLink
       aria-disabled={isPending()}
       class={cn(
         buttonVariants({ variant: "outline" }),
@@ -52,11 +51,10 @@ export function MagicLinkButton(props: MagicLinkButtonProps) {
           event.preventDefault()
         }
       }}
-      params={{
-        path: isMagicLinkView() ? auth.viewPaths.auth.signIn : magicLinkView()
-      }}
+      href={`${auth.basePaths.auth}/${
+        isMagicLinkView() ? auth.viewPaths.auth.signIn : magicLinkView()
+      }`}
       tabIndex={isPending() ? -1 : undefined}
-      to="/auth/$path"
     >
       {isMagicLinkView() ? <Lock /> : <Mail />}
       {auth.localization.auth.continueWith.replace(
@@ -65,6 +63,6 @@ export function MagicLinkButton(props: MagicLinkButtonProps) {
           ? auth.localization.auth.password
           : magicLinkLabels().magicLink
       )}
-    </Link>
+    </AuthLink>
   )
 }

--- a/examples/start-solid-zaidan-example/src/components/auth/magic-link-sent.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/magic-link-sent.tsx
@@ -3,8 +3,7 @@ import {
   type MagicLinkLocalization,
   magicLinkLocalization
 } from "@better-auth-ui/core/plugins"
-import { useAuth } from "@better-auth-ui/solid"
-import { Link } from "@tanstack/solid-router"
+import { AuthLink, useAuth } from "@better-auth-ui/solid"
 import { createSignal, onMount, Show } from "solid-js"
 import { isServer } from "solid-js/web"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -78,12 +77,11 @@ export function MagicLinkSent(props: MagicLinkSentProps) {
         <Show when={auth.emailAndPassword?.enabled}>
           <p class="mt-4 text-center text-muted-foreground text-sm">
             {auth.localization.auth.needToCreateAnAccount}{" "}
-            <Link
-              params={{ path: auth.viewPaths.auth.signUp }}
-              to="/auth/$path"
+            <AuthLink
+              href={`${auth.basePaths.auth}/${auth.viewPaths.auth.signUp}`}
             >
               {auth.localization.auth.signUp}
-            </Link>
+            </AuthLink>
           </p>
         </Show>
       </CardContent>

--- a/examples/start-solid-zaidan-example/src/components/auth/magic-link.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/magic-link.tsx
@@ -4,13 +4,13 @@ import {
   magicLinkLocalization
 } from "@better-auth-ui/core/plugins"
 import {
+  AuthLink,
   type MagicLinkAuthClient,
   signInMagicLinkOptions,
   useAuth
 } from "@better-auth-ui/solid"
 import type { AuthPlugin } from "@better-auth-ui/solid/plugins"
 import { createMutation } from "@tanstack/solid-query"
-import { Link } from "@tanstack/solid-router"
 import { type Component, createSignal, For, Show } from "solid-js"
 import { MAGIC_LINK_SENT_STORAGE_KEY } from "@/components/auth/magic-link-sent"
 import {
@@ -156,12 +156,11 @@ export function MagicLink(props: MagicLinkProps) {
         <Show when={auth.emailAndPassword?.enabled}>
           <p class="mt-4 text-center text-muted-foreground text-sm">
             {auth.localization.auth.needToCreateAnAccount}{" "}
-            <Link
-              params={{ path: auth.viewPaths.auth.signUp }}
-              to="/auth/$path"
+            <AuthLink
+              href={`${auth.basePaths.auth}/${auth.viewPaths.auth.signUp}`}
             >
               {auth.localization.auth.signUp}
-            </Link>
+            </AuthLink>
           </p>
         </Show>
       </CardContent>

--- a/examples/start-solid-zaidan-example/src/components/auth/multi-session/switch-account-submenu-content.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/multi-session/switch-account-submenu-content.tsx
@@ -4,13 +4,13 @@ import {
   multiSessionLocalization
 } from "@better-auth-ui/core/plugins"
 import {
+  AuthLink,
   listDeviceSessionsOptions,
   type MultiSessionAuthClient,
   useAuth,
   useSession
 } from "@better-auth-ui/solid"
 import { createQuery } from "@tanstack/solid-query"
-import { Link } from "@tanstack/solid-router"
 import { Check, CirclePlus } from "lucide-solid"
 import { For, Show } from "solid-js"
 import { shouldLoadDeviceSessions } from "@/components/auth/settings/shared/helpers"
@@ -76,14 +76,13 @@ export function SwitchAccountSubmenuContent() {
       <DropdownMenuSeparator />
 
       <DropdownMenuItem class="gap-1.5 rounded-md px-1.5 py-1 text-sm focus:bg-accent focus:text-accent-foreground">
-        <Link
+        <AuthLink
           class="flex w-full items-center gap-1.5"
-          params={{ path: auth.viewPaths.auth.signIn }}
-          to="/auth/$path"
+          href={`${auth.basePaths.auth}/${auth.viewPaths.auth.signIn}`}
         >
           <CirclePlus class="size-4 text-muted-foreground" />
           {multiSessionLabels().addAccount}
-        </Link>
+        </AuthLink>
       </DropdownMenuItem>
     </DropdownMenuSubContent>
   )

--- a/examples/start-solid-zaidan-example/src/components/auth/phone-number/forgot-phone-number-password.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/phone-number/forgot-phone-number-password.tsx
@@ -1,4 +1,5 @@
 import {
+  AuthLink,
   type PhoneNumberAuthClient,
   requestPhoneNumberPasswordResetOptions,
   useAuth,
@@ -6,7 +7,6 @@ import {
   useFetchOptions
 } from "@better-auth-ui/solid"
 import { createMutation } from "@tanstack/solid-query"
-import { Link } from "@tanstack/solid-router"
 import { createSignal, Show } from "solid-js"
 
 import { Button } from "@/components/ui/button"
@@ -116,13 +116,12 @@ export function ForgotPhoneNumberPassword(
       <CardFooter class="justify-center">
         <p class="text-sm text-muted-foreground">
           {auth.localization.auth.rememberYourPassword}{" "}
-          <Link
+          <AuthLink
             class="underline underline-offset-4"
-            params={{ path: phoneNumberViewPaths.auth.phoneNumber }}
-            to="/auth/$path"
+            href={`${auth.basePaths.auth}/${phoneNumberViewPaths.auth.phoneNumber}`}
           >
             {auth.localization.auth.signIn}
-          </Link>
+          </AuthLink>
         </p>
       </CardFooter>
     </Card>

--- a/examples/start-solid-zaidan-example/src/components/auth/phone-number/phone-number-button.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/phone-number/phone-number-button.tsx
@@ -1,6 +1,5 @@
 import type { AuthView } from "@better-auth-ui/core"
-import { useAuth, useAuthPlugin } from "@better-auth-ui/solid"
-import { Link } from "@tanstack/solid-router"
+import { AuthLink, useAuth, useAuthPlugin } from "@better-auth-ui/solid"
 import { Lock, Smartphone } from "lucide-solid"
 import { Show } from "solid-js"
 
@@ -22,14 +21,13 @@ export function PhoneNumberButton(props: PhoneNumberButtonProps) {
 
   return (
     <Show when={isVisible()}>
-      <Link
+      <AuthLink
         class={cn(buttonVariants({ variant: "outline" }), "w-full")}
-        params={{
-          path: isPhoneNumberView()
+        href={`${auth.basePaths.auth}/${
+          isPhoneNumberView()
             ? auth.viewPaths.auth.signIn
             : phoneNumberViewPaths.auth.phoneNumber
-        }}
-        to="/auth/$path"
+        }`}
       >
         <Show fallback={<Smartphone />} when={isPhoneNumberView()}>
           <Lock />
@@ -40,7 +38,7 @@ export function PhoneNumberButton(props: PhoneNumberButtonProps) {
             ? auth.localization.auth.password
             : phoneLocalization.phoneNumber
         )}
-      </Link>
+      </AuthLink>
     </Show>
   )
 }

--- a/examples/start-solid-zaidan-example/src/components/auth/phone-number/phone-number.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/phone-number/phone-number.tsx
@@ -1,4 +1,5 @@
 import {
+  AuthLink,
   AuthPrompts,
   type PhoneNumberAuthClient,
   sendPhoneNumberOtpOptions,
@@ -10,7 +11,6 @@ import {
 } from "@better-auth-ui/solid"
 import type { AuthPlugin } from "@better-auth-ui/solid/plugins"
 import { createMutation } from "@tanstack/solid-query"
-import { Link } from "@tanstack/solid-router"
 import type { BetterFetchError } from "better-auth/client"
 import { type Component, createSignal, For, Show } from "solid-js"
 
@@ -351,26 +351,22 @@ export function PhoneNumber(props: PhoneNumberProps) {
         </div>
         <div class="mt-4 flex w-full flex-col items-center gap-3">
           <Show when={mode() === "password" && passwordReset}>
-            <Link
+            <AuthLink
               class="text-sm underline-offset-4 hover:underline"
-              params={{
-                path: phoneNumberViewPaths.auth.phoneNumberForgotPassword
-              }}
-              to="/auth/$path"
+              href={`${auth.basePaths.auth}/${phoneNumberViewPaths.auth.phoneNumberForgotPassword}`}
             >
               {localization.forgotPassword}
-            </Link>
+            </AuthLink>
           </Show>
           <Show when={auth.emailAndPassword?.enabled}>
             <p class="text-center text-sm text-muted-foreground">
               {auth.localization.auth.needToCreateAnAccount}{" "}
-              <Link
+              <AuthLink
                 class="underline underline-offset-4"
-                params={{ path: auth.viewPaths.auth.signUp }}
-                to="/auth/$path"
+                href={`${auth.basePaths.auth}/${auth.viewPaths.auth.signUp}`}
               >
                 {auth.localization.auth.signUp}
-              </Link>
+              </AuthLink>
             </p>
           </Show>
         </div>

--- a/examples/start-solid-zaidan-example/src/components/auth/reset-link-sent.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/reset-link-sent.tsx
@@ -1,3 +1,4 @@
+import { getAuthLinkURL } from "@better-auth-ui/core"
 import { AuthLink, useAuth } from "@better-auth-ui/solid"
 import { createSignal, onMount, Show } from "solid-js"
 import { isServer } from "solid-js/web"
@@ -67,7 +68,10 @@ export function ResetLinkSent(props: ResetLinkSentProps) {
             {auth.localization.auth.rememberYourPassword}{" "}
             <AuthLink
               class="underline underline-offset-4"
-              href={`${auth.basePaths.auth}/${auth.viewPaths.auth.signIn}`}
+              href={getAuthLinkURL(
+                `${auth.basePaths.auth}/${auth.viewPaths.auth.signIn}`,
+                auth.redirectTo
+              )}
             >
               {auth.localization.auth.signIn}
             </AuthLink>

--- a/examples/start-solid-zaidan-example/src/components/auth/reset-link-sent.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/reset-link-sent.tsx
@@ -1,5 +1,4 @@
-import { useAuth } from "@better-auth-ui/solid"
-import { Link } from "@tanstack/solid-router"
+import { AuthLink, useAuth } from "@better-auth-ui/solid"
 import { createSignal, onMount, Show } from "solid-js"
 import { isServer } from "solid-js/web"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -66,13 +65,12 @@ export function ResetLinkSent(props: ResetLinkSentProps) {
         <div class="mt-4 flex w-full flex-col items-center gap-3">
           <p class="text-center text-sm text-muted-foreground">
             {auth.localization.auth.rememberYourPassword}{" "}
-            <Link
+            <AuthLink
               class="underline underline-offset-4"
-              params={{ path: auth.viewPaths.auth.signIn }}
-              to="/auth/$path"
+              href={`${auth.basePaths.auth}/${auth.viewPaths.auth.signIn}`}
             >
               {auth.localization.auth.signIn}
-            </Link>
+            </AuthLink>
           </p>
         </div>
       </CardContent>

--- a/examples/start-solid-zaidan-example/src/components/auth/reset-password.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/reset-password.tsx
@@ -1,3 +1,4 @@
+import { getAuthLinkURL } from "@better-auth-ui/core"
 import { AuthLink, resetPasswordOptions, useAuth } from "@better-auth-ui/solid"
 import { createMutation } from "@tanstack/solid-query"
 import { Eye, EyeOff } from "lucide-solid"
@@ -216,7 +217,10 @@ export function ResetPassword(props: ResetPasswordProps) {
             {auth.localization.auth.rememberYourPassword}{" "}
             <AuthLink
               class="underline underline-offset-4"
-              href={`${auth.basePaths.auth}/${auth.viewPaths.auth.signIn}`}
+              href={getAuthLinkURL(
+                `${auth.basePaths.auth}/${auth.viewPaths.auth.signIn}`,
+                auth.redirectTo
+              )}
             >
               {auth.localization.auth.signIn}
             </AuthLink>

--- a/examples/start-solid-zaidan-example/src/components/auth/reset-password.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/reset-password.tsx
@@ -1,6 +1,5 @@
-import { resetPasswordOptions, useAuth } from "@better-auth-ui/solid"
+import { AuthLink, resetPasswordOptions, useAuth } from "@better-auth-ui/solid"
 import { createMutation } from "@tanstack/solid-query"
-import { Link } from "@tanstack/solid-router"
 import { Eye, EyeOff } from "lucide-solid"
 import { createSignal, Show } from "solid-js"
 import { Alert, AlertDescription } from "@/components/ui/alert"
@@ -215,13 +214,12 @@ export function ResetPassword(props: ResetPasswordProps) {
         <div class="mt-4 flex w-full flex-col items-center gap-3">
           <p class="text-center text-sm text-muted-foreground">
             {auth.localization.auth.rememberYourPassword}{" "}
-            <Link
+            <AuthLink
               class="underline underline-offset-4"
-              params={{ path: auth.viewPaths.auth.signIn }}
-              to="/auth/$path"
+              href={`${auth.basePaths.auth}/${auth.viewPaths.auth.signIn}`}
             >
               {auth.localization.auth.signIn}
-            </Link>
+            </AuthLink>
           </p>
         </div>
       </CardContent>

--- a/examples/start-solid-zaidan-example/src/components/auth/settings/account/change-email.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/settings/account/change-email.tsx
@@ -1,3 +1,4 @@
+import { getViewURL } from "@better-auth-ui/core"
 import { changeEmailOptions, useAuth, useSession } from "@better-auth-ui/solid"
 import { createMutation } from "@tanstack/solid-query"
 import { createSignal, Show } from "solid-js"
@@ -28,7 +29,11 @@ export function ChangeEmail(props: ChangeEmailProps = {}) {
     const formData = new FormData(event.currentTarget as HTMLFormElement)
 
     changeEmail.mutate({
-      callbackURL: `${auth.baseURL}/${auth.viewPaths.settings.account}`,
+      callbackURL: getViewURL(
+        auth.baseURL,
+        auth.basePaths.settings,
+        auth.viewPaths.settings.account
+      ),
       newEmail: String(formData.get("email") ?? "")
     } as Parameters<typeof changeEmail.mutate>[0])
   }

--- a/examples/start-solid-zaidan-example/src/components/auth/settings/security/change-password.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/settings/security/change-password.tsx
@@ -1,3 +1,4 @@
+import { getViewURL } from "@better-auth-ui/core"
 import {
   changePasswordOptions,
   listAccountsOptions,
@@ -103,7 +104,12 @@ export function ChangePasswordSettings(
     if (!session.data) return
 
     requestPasswordReset.mutate({
-      email: session.data.user.email
+      email: session.data.user.email,
+      redirectTo: getViewURL(
+        auth.baseURL,
+        auth.basePaths.auth,
+        auth.viewPaths.auth.resetPassword
+      )
     } as Parameters<typeof requestPasswordReset.mutate>[0])
   }
 

--- a/examples/start-solid-zaidan-example/src/components/auth/sign-up.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/sign-up.tsx
@@ -60,7 +60,10 @@ export function SignUp(props: SignUpProps) {
       if (auth.emailAndPassword.requireEmailVerification) {
         sessionStorage.setItem("better-auth-ui.verify-email", variables.email)
         auth.navigate({
-          to: `${auth.basePaths.auth}/${auth.viewPaths.auth.verifyEmail}`
+          to: getAuthLinkURL(
+            `${auth.basePaths.auth}/${auth.viewPaths.auth.verifyEmail}`,
+            auth.redirectTo
+          )
         })
         return
       }

--- a/examples/start-solid-zaidan-example/src/components/auth/sign-up.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/sign-up.tsx
@@ -1,4 +1,8 @@
-import { authQueryKeys, parseAdditionalFieldValue } from "@better-auth-ui/core"
+import {
+  authQueryKeys,
+  getAuthLinkURL,
+  parseAdditionalFieldValue
+} from "@better-auth-ui/core"
 import {
   AuthLink,
   AuthPrompts,
@@ -391,7 +395,10 @@ export function SignUp(props: SignUpProps) {
             {auth.localization.auth.alreadyHaveAnAccount}{" "}
             <AuthLink
               class="underline underline-offset-4"
-              href={`${auth.basePaths.auth}/${auth.viewPaths.auth.signIn}`}
+              href={getAuthLinkURL(
+                `${auth.basePaths.auth}/${auth.viewPaths.auth.signIn}`,
+                auth.redirectTo
+              )}
             >
               {auth.localization.auth.signIn}
             </AuthLink>

--- a/examples/start-solid-zaidan-example/src/components/auth/sign-up.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/sign-up.tsx
@@ -1,5 +1,6 @@
 import { authQueryKeys, parseAdditionalFieldValue } from "@better-auth-ui/core"
 import {
+  AuthLink,
   AuthPrompts,
   signUpEmailOptions,
   useAuth,
@@ -7,7 +8,6 @@ import {
 } from "@better-auth-ui/solid"
 import type { AuthPlugin } from "@better-auth-ui/solid/plugins"
 import { createMutation, useQueryClient } from "@tanstack/solid-query"
-import { Link } from "@tanstack/solid-router"
 import { Eye, EyeOff } from "lucide-solid"
 import { createSignal, For, Show } from "solid-js"
 import { toast } from "solid-sonner"
@@ -389,13 +389,12 @@ export function SignUp(props: SignUpProps) {
         <div class="mt-4 flex w-full flex-col items-center gap-3">
           <p class="text-center text-sm text-muted-foreground">
             {auth.localization.auth.alreadyHaveAnAccount}{" "}
-            <Link
+            <AuthLink
               class="underline underline-offset-4"
-              params={{ path: auth.viewPaths.auth.signIn }}
-              to="/auth/$path"
+              href={`${auth.basePaths.auth}/${auth.viewPaths.auth.signIn}`}
             >
               {auth.localization.auth.signIn}
-            </Link>
+            </AuthLink>
           </p>
         </div>
       </CardContent>

--- a/examples/start-solid-zaidan-example/src/components/auth/two-factor/two-factor-challenge.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/two-factor/two-factor-challenge.tsx
@@ -1,4 +1,5 @@
 import {
+  AuthLink,
   sendTwoFactorOtpOptions,
   type TwoFactorAuthClient,
   useAuth,
@@ -8,7 +9,6 @@ import {
   verifyTwoFactorOtpOptions
 } from "@better-auth-ui/solid"
 import { createMutation } from "@tanstack/solid-query"
-import { Link } from "@tanstack/solid-router"
 import { createSignal, For, Show } from "solid-js"
 
 import { OtpField } from "@/components/auth/otp-field"
@@ -325,13 +325,12 @@ export function TwoFactorChallenge(props: TwoFactorChallengeProps) {
       </CardContent>
 
       <CardFooter class="justify-center">
-        <Link
+        <AuthLink
           class="text-sm underline underline-offset-4"
-          params={{ path: auth.viewPaths.auth.signIn }}
-          to="/auth/$path"
+          href={`${auth.basePaths.auth}/${auth.viewPaths.auth.signIn}`}
         >
           {twoFactorLocalization.backToSignIn}
-        </Link>
+        </AuthLink>
       </CardFooter>
     </Card>
   )

--- a/examples/start-solid-zaidan-example/src/components/auth/user/user-button.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/user/user-button.tsx
@@ -1,5 +1,4 @@
-import { useAuth, useSession } from "@better-auth-ui/solid"
-import { Link } from "@tanstack/solid-router"
+import { AuthLink, useAuth, useSession } from "@better-auth-ui/solid"
 import {
   ChevronsUpDown,
   LogIn,
@@ -307,25 +306,23 @@ function MountedUserButton(rawProps: UserButtonProps = {}) {
                   <For each={userLinks()}>{renderUserLink}</For>
 
                   <DropdownMenuItem class="z-dropdown-menu-item-auth hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground data-expanded:bg-accent data-expanded:text-accent-foreground">
-                    <Link
+                    <AuthLink
                       class={menuLinkClass}
-                      params={{ path: signInPath }}
-                      to="/auth/$path"
+                      href={`${auth.basePaths.auth}/${signInPath}`}
                     >
                       <LogIn class="size-4 text-muted-foreground" />
                       {auth.localization.auth.signIn}
-                    </Link>
+                    </AuthLink>
                   </DropdownMenuItem>
 
                   <DropdownMenuItem class="z-dropdown-menu-item-auth hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground data-expanded:bg-accent data-expanded:text-accent-foreground">
-                    <Link
+                    <AuthLink
                       class={menuLinkClass}
-                      params={{ path: signUpPath }}
-                      to="/auth/$path"
+                      href={`${auth.basePaths.auth}/${signUpPath}`}
                     >
                       <UserPlus2 class="size-4 text-muted-foreground" />
                       {auth.localization.auth.signUp}
-                    </Link>
+                    </AuthLink>
                   </DropdownMenuItem>
                 </>
               }
@@ -334,14 +331,13 @@ function MountedUserButton(rawProps: UserButtonProps = {}) {
 
               <Show when={!props.hideSettings}>
                 <DropdownMenuItem class="z-dropdown-menu-item-auth hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground data-expanded:bg-accent data-expanded:text-accent-foreground">
-                  <Link
+                  <AuthLink
                     class={menuLinkClass}
-                    params={{ path: settingsPath }}
-                    to="/settings/$path"
+                    href={`${auth.basePaths.settings}/${settingsPath}`}
                   >
                     <Settings class="size-4 text-muted-foreground" />
                     {settingsLabel()}
-                  </Link>
+                  </AuthLink>
                 </DropdownMenuItem>
               </Show>
 
@@ -357,14 +353,13 @@ function MountedUserButton(rawProps: UserButtonProps = {}) {
               <DropdownMenuSeparator class="my-1 bg-border" />
 
               <DropdownMenuItem class="z-dropdown-menu-item-auth hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground data-expanded:bg-accent data-expanded:text-accent-foreground">
-                <Link
+                <AuthLink
                   class={menuLinkClass}
-                  params={{ path: signOutPath }}
-                  to="/auth/$path"
+                  href={`${auth.basePaths.auth}/${signOutPath}`}
                 >
                   <LogOut class="size-4 text-muted-foreground" />
                   {auth.localization.auth.signOut}
-                </Link>
+                </AuthLink>
               </DropdownMenuItem>
             </Show>
           </Show>

--- a/examples/start-solid-zaidan-example/src/components/auth/username/sign-in-username.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/username/sign-in-username.tsx
@@ -4,6 +4,7 @@ import {
   usernameLocalization
 } from "@better-auth-ui/core/plugins"
 import {
+  AuthLink,
   AuthPrompts,
   signInEmailOptions,
   signInUsernameOptions,
@@ -13,7 +14,6 @@ import {
 } from "@better-auth-ui/solid"
 import type { AuthPlugin } from "@better-auth-ui/solid/plugins"
 import { createMutation, useQueryClient } from "@tanstack/solid-query"
-import { Link } from "@tanstack/solid-router"
 import type { BetterFetchError } from "better-auth/client"
 import { Eye, EyeOff } from "lucide-solid"
 import { type Component, createSignal, For, Show } from "solid-js"
@@ -286,24 +286,22 @@ export function SignInUsername(props: SignInUsernameProps) {
 
         <div class="mt-4 flex w-full flex-col items-center gap-3">
           <Show when={auth.emailAndPassword.forgotPassword}>
-            <Link
+            <AuthLink
               class="text-sm underline-offset-4 hover:underline"
-              params={{ path: auth.viewPaths.auth.forgotPassword }}
-              to="/auth/$path"
+              href={`${auth.basePaths.auth}/${auth.viewPaths.auth.forgotPassword}`}
             >
               {auth.localization.auth.forgotPasswordLink}
-            </Link>
+            </AuthLink>
           </Show>
 
           <p class="text-center text-sm text-muted-foreground">
             {auth.localization.auth.needToCreateAnAccount}{" "}
-            <Link
+            <AuthLink
               class="underline underline-offset-4"
-              params={{ path: auth.viewPaths.auth.signUp }}
-              to="/auth/$path"
+              href={`${auth.basePaths.auth}/${auth.viewPaths.auth.signUp}`}
             >
               {auth.localization.auth.signUp}
-            </Link>
+            </AuthLink>
           </p>
         </div>
       </CardContent>

--- a/examples/start-solid-zaidan-example/src/components/auth/verify-email.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/verify-email.tsx
@@ -1,6 +1,9 @@
-import { sendVerificationEmailOptions, useAuth } from "@better-auth-ui/solid"
+import {
+  AuthLink,
+  sendVerificationEmailOptions,
+  useAuth
+} from "@better-auth-ui/solid"
 import { createMutation } from "@tanstack/solid-query"
-import { Link } from "@tanstack/solid-router"
 import { createSignal, onCleanup, onMount } from "solid-js"
 import { isServer } from "solid-js/web"
 import { toast } from "solid-sonner"
@@ -104,13 +107,12 @@ export function VerifyEmail(props: VerifyEmailProps) {
         <div class="mt-4 flex w-full flex-col items-center gap-3">
           <p class="text-center text-sm text-muted-foreground">
             {auth.localization.auth.alreadyVerifiedYourEmail}{" "}
-            <Link
+            <AuthLink
               class="underline underline-offset-4"
-              params={{ path: auth.viewPaths.auth.signIn }}
-              to="/auth/$path"
+              href={`${auth.basePaths.auth}/${auth.viewPaths.auth.signIn}`}
             >
               {auth.localization.auth.signIn}
-            </Link>
+            </AuthLink>
           </p>
         </div>
       </CardContent>

--- a/examples/start-solid-zaidan-example/src/components/providers.tsx
+++ b/examples/start-solid-zaidan-example/src/components/providers.tsx
@@ -1,8 +1,13 @@
 import { deleteUserPlugin } from "@better-auth-ui/core/plugins"
+import type { AuthLinkProps } from "@better-auth-ui/solid"
 import type { QueryClient } from "@tanstack/solid-query"
-import { useNavigate, useParams } from "@tanstack/solid-router"
+import {
+  Link as RouterLink,
+  useNavigate,
+  useParams
+} from "@tanstack/solid-router"
 import type { JSX } from "solid-js"
-import { onCleanup, onMount, Show } from "solid-js"
+import { onCleanup, onMount, Show, splitProps } from "solid-js"
 import { apiKeyPlugin } from "@/lib/auth/api-key-plugin"
 import { emailOtpPlugin } from "@/lib/auth/email-otp-plugin"
 import { magicLinkPlugin } from "@/lib/auth/magic-link-plugin"
@@ -26,6 +31,12 @@ export type ProvidersProps = {
 const resolveProviderChildren = (children: ProvidersProps["children"]) =>
   typeof children === "function" ? children() : children
 
+function AuthLink(props: AuthLinkProps) {
+  const [local, linkProps] = splitProps(props, ["href"])
+
+  return <RouterLink {...linkProps} to={local.href} />
+}
+
 export function Providers(props: ProvidersProps) {
   const navigate = useNavigate()
   const params = useParams({ strict: false })
@@ -47,6 +58,7 @@ export function Providers(props: ProvidersProps) {
     <Show keyed when={organizationSlug() ?? "personal"}>
       <AuthProvider
         authClient={authClient}
+        Link={AuthLink}
         redirectTo="/settings/account"
         navigate={navigate}
         queryClient={props.queryClient}

--- a/examples/start-solid-zaidan-example/src/routeTree.gen.ts
+++ b/examples/start-solid-zaidan-example/src/routeTree.gen.ts
@@ -10,19 +10,14 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
-import { Route as AuthPathRouteImport } from './routes/auth/$path'
 import { Route as SettingsPathRouteImport } from './routes/settings/$path'
-import { Route as ApiAuthSplatRouteImport } from './routes/api/auth/$'
+import { Route as AuthPathRouteImport } from './routes/auth/$path'
 import { Route as OrganizationAtChar123slugChar125PathRouteImport } from './routes/organization/@{$slug}/$path'
+import { Route as ApiAuthSplatRouteImport } from './routes/api/auth/$'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const AuthPathRoute = AuthPathRouteImport.update({
-  id: '/auth/$path',
-  path: '/auth/$path',
   getParentRoute: () => rootRouteImport,
 } as any)
 const SettingsPathRoute = SettingsPathRouteImport.update({
@@ -30,9 +25,9 @@ const SettingsPathRoute = SettingsPathRouteImport.update({
   path: '/settings/$path',
   getParentRoute: () => rootRouteImport,
 } as any)
-const ApiAuthSplatRoute = ApiAuthSplatRouteImport.update({
-  id: '/api/auth/$',
-  path: '/api/auth/$',
+const AuthPathRoute = AuthPathRouteImport.update({
+  id: '/auth/$path',
+  path: '/auth/$path',
   getParentRoute: () => rootRouteImport,
 } as any)
 const OrganizationAtChar123slugChar125PathRoute =
@@ -41,6 +36,11 @@ const OrganizationAtChar123slugChar125PathRoute =
     path: '/organization/@{$slug}/$path',
     getParentRoute: () => rootRouteImport,
   } as any)
+const ApiAuthSplatRoute = ApiAuthSplatRouteImport.update({
+  id: '/api/auth/$',
+  path: '/api/auth/$',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -105,13 +105,6 @@ declare module '@tanstack/solid-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/auth/$path': {
-      id: '/auth/$path'
-      path: '/auth/$path'
-      fullPath: '/auth/$path'
-      preLoaderRoute: typeof AuthPathRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/settings/$path': {
       id: '/settings/$path'
       path: '/settings/$path'
@@ -119,11 +112,11 @@ declare module '@tanstack/solid-router' {
       preLoaderRoute: typeof SettingsPathRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/api/auth/$': {
-      id: '/api/auth/$'
-      path: '/api/auth/$'
-      fullPath: '/api/auth/$'
-      preLoaderRoute: typeof ApiAuthSplatRouteImport
+    '/auth/$path': {
+      id: '/auth/$path'
+      path: '/auth/$path'
+      fullPath: '/auth/$path'
+      preLoaderRoute: typeof AuthPathRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/organization/@{$slug}/$path': {
@@ -131,6 +124,13 @@ declare module '@tanstack/solid-router' {
       path: '/organization/@{$slug}/$path'
       fullPath: '/organization/@{$slug}/$path'
       preLoaderRoute: typeof OrganizationAtChar123slugChar125PathRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/auth/$': {
+      id: '/api/auth/$'
+      path: '/api/auth/$'
+      fullPath: '/api/auth/$'
+      preLoaderRoute: typeof ApiAuthSplatRouteImport
       parentRoute: typeof rootRouteImport
     }
   }

--- a/examples/start-solid-zaidan-example/tests/auth-route.test.ts
+++ b/examples/start-solid-zaidan-example/tests/auth-route.test.ts
@@ -173,9 +173,6 @@ describe("Solid auth route component selection", () => {
       "utf8"
     )
 
-    expect(providers).toContain(
-      'import { useNavigate, useParams } from "@tanstack/solid-router"'
-    )
     expect(providers).toContain("useParams({ strict: false })")
     expect(providers).toContain('typeof slug === "string"')
     expect(providers).toContain("return null")
@@ -827,27 +824,6 @@ describe("Solid auth route component selection", () => {
     )
   })
 
-  it("uses TanStack Link for UserButton auth/settings menu navigation", () => {
-    const userButton = readFileSync(
-      resolve(__dirname, "../src/components/auth/user/user-button.tsx"),
-      "utf8"
-    )
-
-    expect(userButton).toContain(
-      'import { Link } from "@tanstack/solid-router"'
-    )
-    expect(userButton).toContain('to="/auth/$path"')
-    expect(userButton).toContain('to="/settings/$path"')
-    expect(userButton).toContain("params={{ path: signInPath }}")
-    expect(userButton).toContain("params={{ path: signUpPath }}")
-    expect(userButton).toContain("params={{ path: settingsPath }}")
-    expect(userButton).toContain("params={{ path: signOutPath }}")
-    expect(userButton).not.toContain('as="a"')
-    expect(userButton).not.toMatch(
-      /href=\{(?:signInHref|signUpHref|settingsHref|signOutHref)\}/
-    )
-  })
-
   it("wires Theme through the local plugin instead of hard-coded user/account surfaces", () => {
     const providers = readFileSync(
       resolve(__dirname, "../src/components/providers.tsx"),
@@ -1170,7 +1146,6 @@ describe("Solid auth route component selection", () => {
     expect(switchAccountSubmenuContent).toContain("shouldLoadDeviceSessions")
     expect(switchAccountSubmenuContent).toContain("DropdownMenuSubContent")
     expect(switchAccountSubmenuContent).toContain("SwitchAccountSubmenuItem")
-    expect(switchAccountSubmenuContent).toContain('to="/auth/$path"')
     expect(switchAccountSubmenuContent).toContain("auth.viewPaths.auth.signIn")
     expect(switchAccountSubmenuContent).toContain("CirclePlus")
 
@@ -1421,31 +1396,6 @@ describe("Solid auth route component selection", () => {
 
       expect(source, implementation.file).toContain(implementation.expected)
       expect(isSimpleReExportOnly(source), implementation.file).toBe(false)
-    }
-  })
-
-  it("uses TanStack Link for auth form helper navigation", () => {
-    const helperLinkFiles = [
-      "username/sign-in-username.tsx",
-      "sign-up.tsx",
-      "forgot-password.tsx",
-      "reset-password.tsx"
-    ]
-
-    for (const file of helperLinkFiles) {
-      const source = readFileSync(
-        resolve(__dirname, `../src/components/auth/${file}`),
-        "utf8"
-      )
-
-      expect(source, file).toContain(
-        'import { Link } from "@tanstack/solid-router"'
-      )
-      expect(source, file).toContain("<Link")
-      expect(source, file).toContain('to="/auth/$path"')
-      expect(source, file).toContain("params={{ path: auth.viewPaths.auth.")
-      expect(source, file).not.toMatch(/<a\s/)
-      expect(source, file).not.toMatch(/href=\{?`?\$?\{?auth\.basePaths\.auth/)
     }
   })
 

--- a/examples/start-solid-zaidan-example/tests/auth-route.test.ts
+++ b/examples/start-solid-zaidan-example/tests/auth-route.test.ts
@@ -1,10 +1,21 @@
 import { existsSync, readFileSync } from "node:fs"
 import { resolve } from "node:path"
 import { viewPaths } from "@better-auth-ui/core"
-import { describe, expect, it } from "vitest"
+import {
+  type AuthLinkProps,
+  AuthProvider as SolidAuthProvider
+} from "@better-auth-ui/solid"
+import { createComponent, type JSX } from "solid-js"
+import { renderToString } from "solid-js/web"
+import { afterEach, describe, expect, it, vi } from "vitest"
 import { resolveAuthRoute } from "../src/components/auth/auth"
 import { AuthRedirect } from "../src/components/auth/auth-redirect"
+import { EmailOtpButton } from "../src/components/auth/email-otp/email-otp-button"
+import { ForgotPasswordOtp } from "../src/components/auth/email-otp/forgot-password-otp"
+import { ResetPasswordOtp } from "../src/components/auth/email-otp/reset-password-otp"
+import { VerifyEmailOtp } from "../src/components/auth/email-otp/verify-email-otp"
 import { ForgotPassword } from "../src/components/auth/forgot-password"
+import { ResetLinkSent } from "../src/components/auth/reset-link-sent"
 import { ResetPassword } from "../src/components/auth/reset-password"
 import { AccountSettings } from "../src/components/auth/settings/account/account-settings"
 import {
@@ -28,6 +39,11 @@ import {
 } from "../src/components/auth/sign-in-path"
 import { SignOut } from "../src/components/auth/sign-out"
 import { SignUp } from "../src/components/auth/sign-up"
+import { emailOtpPlugin } from "../src/lib/auth/email-otp-plugin"
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
 
 const isSimpleReExportOnly = (source: string) => {
   const statement = source
@@ -165,6 +181,84 @@ describe("Solid auth route component selection", () => {
     expect(authServer).toContain('"http://localhost:3000"')
     expect(authProvider).not.toContain("useNavigate")
     expect(authProvider).not.toContain("createAuthClient")
+  })
+
+  it("preserves the current redirect target across auth-page link transitions", () => {
+    const redirectTo = "/projects/acme?tab=members"
+    vi.stubGlobal("window", {
+      location: {
+        search: `?redirectTo=${encodeURIComponent(redirectTo)}`
+      }
+    })
+
+    const authClient = {
+      emailOtp: {
+        requestPasswordReset: vi.fn(),
+        resetPassword: vi.fn(),
+        sendVerificationOtp: vi.fn(),
+        verifyEmail: vi.fn()
+      },
+      getSession: vi.fn(),
+      resetPassword: vi.fn(),
+      signUp: { email: vi.fn() }
+    }
+    const plugin = emailOtpPlugin({
+      emailVerification: true,
+      passwordReset: true,
+      signIn: true
+    })
+    const signInURL = `/auth/${viewPaths.auth.signIn}?redirectTo=${encodeURIComponent(redirectTo)}`
+    const emailOtpURL = `/auth/${plugin.viewPaths.auth.emailOtp}?redirectTo=${encodeURIComponent(redirectTo)}`
+
+    const captureLink = (
+      renderPage: () => JSX.Element,
+      plugins: [typeof plugin] | [] = []
+    ) => {
+      const hrefs: string[] = []
+      const Link = (props: AuthLinkProps) => {
+        hrefs.push(props.href)
+        return null
+      }
+
+      renderToString(() =>
+        createComponent(SolidAuthProvider, {
+          authClient: authClient as never,
+          Link,
+          navigate: vi.fn(),
+          plugins,
+          children: renderPage
+        })
+      )
+
+      expect(hrefs).toHaveLength(1)
+      return hrefs[0]
+    }
+
+    expect(
+      captureLink(() => createComponent(EmailOtpButton, {}), [plugin])
+    ).toBe(emailOtpURL)
+    expect(
+      captureLink(
+        () => createComponent(EmailOtpButton, { view: "emailOtp" }),
+        [plugin]
+      )
+    ).toBe(signInURL)
+    expect(
+      captureLink(() => createComponent(ForgotPasswordOtp, {}), [plugin])
+    ).toBe(signInURL)
+    expect(
+      captureLink(() => createComponent(ResetPasswordOtp, {}), [plugin])
+    ).toBe(signInURL)
+    expect(
+      captureLink(() => createComponent(VerifyEmailOtp, {}), [plugin])
+    ).toBe(signInURL)
+    expect(captureLink(() => createComponent(ResetLinkSent, {}))).toBe(
+      signInURL
+    )
+    expect(captureLink(() => createComponent(ResetPassword, {}))).toBe(
+      signInURL
+    )
+    expect(captureLink(() => createComponent(SignUp, {}))).toBe(signInURL)
   })
 
   it("drives the organization plugin from the current route slug", () => {

--- a/examples/start-solid-zaidan-example/tests/registry.test.ts
+++ b/examples/start-solid-zaidan-example/tests/registry.test.ts
@@ -1864,11 +1864,6 @@ describe("Solid registry isolation", () => {
     expect(userButton).toContain('width: "max-content"')
     expect(userButton).toContain("<Show when={session.data}>")
     expect(userButton).toContain("when={!session.isPending}")
-    expect(userButton).toContain(
-      'import { Link } from "@tanstack/solid-router"'
-    )
-    expect(userButton).toContain('to="/settings/$path"')
-    expect(userButton).toContain("params={{ path: settingsPath }}")
     expect(userButton).not.toContain('as="a"')
     expect(userButton).not.toContain(
       "disabled\n            >\n              <Settings"

--- a/packages/core/src/lib/auth-redirect.ts
+++ b/packages/core/src/lib/auth-redirect.ts
@@ -21,6 +21,25 @@ export function getViewURL(
   return `${origin}/${path}`
 }
 
+/**
+ * Add the current post-authentication destination to an internal auth link.
+ */
+export function getAuthLinkURL(href: string, redirectTo: string): string {
+  const hashIndex = href.indexOf("#")
+  const hash = hashIndex === -1 ? "" : href.slice(hashIndex)
+  const hrefWithoutHash = hashIndex === -1 ? href : href.slice(0, hashIndex)
+  const queryIndex = hrefWithoutHash.indexOf("?")
+  const pathname =
+    queryIndex === -1 ? hrefWithoutHash : hrefWithoutHash.slice(0, queryIndex)
+  const searchParams = new URLSearchParams(
+    queryIndex === -1 ? "" : hrefWithoutHash.slice(queryIndex + 1)
+  )
+
+  searchParams.set("redirectTo", redirectTo)
+
+  return `${pathname}?${searchParams}${hash}`
+}
+
 function hasUnsafeRedirectCharacters(value: string): boolean {
   for (const character of value) {
     const codePoint = character.codePointAt(0)

--- a/packages/core/src/lib/auth-redirect.ts
+++ b/packages/core/src/lib/auth-redirect.ts
@@ -1,5 +1,26 @@
 const ABSOLUTE_HTTP_URL = /^https?:\/\//i
 
+/**
+ * Build a callback URL from an optional origin, a configured base path, and a
+ * view path.
+ *
+ * Separators are normalized so custom paths work whether callers include
+ * leading or trailing slashes.
+ */
+export function getViewURL(
+  baseURL: string,
+  basePath: string,
+  viewPath: string
+): string {
+  const origin = baseURL.replace(/\/+$/, "")
+  const path = [basePath, viewPath]
+    .map((segment) => segment.replace(/^\/+|\/+$/g, ""))
+    .filter(Boolean)
+    .join("/")
+
+  return `${origin}/${path}`
+}
+
 function hasUnsafeRedirectCharacters(value: string): boolean {
   for (const character of value) {
     const codePoint = character.codePointAt(0)

--- a/packages/core/tests/auth-redirect.test.ts
+++ b/packages/core/tests/auth-redirect.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest"
 import {
   getAuthRedirectAction,
-  getSafeRedirectTo
+  getSafeRedirectTo,
+  getViewURL
 } from "../src/lib/auth-redirect"
 
 const origin = "https://app.example.com"
@@ -35,6 +36,18 @@ describe("getSafeRedirectTo", () => {
     ["/settings\n/account", "control characters"]
   ])("rejects %s (%s)", (target) => {
     expect(getSafeRedirectTo(target, origin)).toBe("/")
+  })
+})
+
+describe("getViewURL", () => {
+  it("combines an origin, custom base path, and view path", () => {
+    expect(getViewURL("https://example.com/", "/profile/", "/personal/")).toBe(
+      "https://example.com/profile/personal"
+    )
+  })
+
+  it("returns a root-relative path when no origin is configured", () => {
+    expect(getViewURL("", "/login", "new-password")).toBe("/login/new-password")
   })
 })
 

--- a/packages/core/tests/auth-redirect.test.ts
+++ b/packages/core/tests/auth-redirect.test.ts
@@ -1,11 +1,25 @@
 import { describe, expect, it } from "vitest"
 import {
+  getAuthLinkURL,
   getAuthRedirectAction,
   getSafeRedirectTo,
   getViewURL
 } from "../src/lib/auth-redirect"
 
 const origin = "https://app.example.com"
+
+describe("getAuthLinkURL", () => {
+  it("preserves redirect targets and existing URL details", () => {
+    expect(
+      getAuthLinkURL(
+        "/auth/sign-in?mode=password#form",
+        "/projects/acme?tab=members"
+      )
+    ).toBe(
+      "/auth/sign-in?mode=password&redirectTo=%2Fprojects%2Facme%3Ftab%3Dmembers#form"
+    )
+  })
+})
 
 describe("getSafeRedirectTo", () => {
   it("preserves root-relative paths, queries, and hashes", () => {

--- a/packages/heroui/src/components/auth/email-otp/email-otp-button.tsx
+++ b/packages/heroui/src/components/auth/email-otp/email-otp-button.tsx
@@ -1,4 +1,8 @@
-import { type AuthView, authMutationKeys } from "@better-auth-ui/core"
+import {
+  type AuthView,
+  authMutationKeys,
+  getAuthLinkURL
+} from "@better-auth-ui/core"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { Keyboard, Lock } from "@gravity-ui/icons"
 import { cn, Link } from "@heroui/react"
@@ -18,7 +22,8 @@ export type EmailOtpButtonProps = {
  * @param view - Current auth view. On `"emailOtp"` this links back to password sign-in.
  */
 export function EmailOtpButton({ view }: EmailOtpButtonProps) {
-  const { basePaths, emailAndPassword, localization, viewPaths } = useAuth()
+  const { basePaths, emailAndPassword, localization, redirectTo, viewPaths } =
+    useAuth()
   const { localization: emailOtpLocalization, viewPaths: emailOtpViewPaths } =
     useAuthPlugin(emailOtpPlugin)
 
@@ -38,7 +43,10 @@ export function EmailOtpButton({ view }: EmailOtpButtonProps) {
 
   return (
     <Link
-      href={`${basePaths.auth}/${isEmailOtpView ? viewPaths.auth.signIn : emailOtpViewPaths.auth.emailOtp}`}
+      href={getAuthLinkURL(
+        `${basePaths.auth}/${isEmailOtpView ? viewPaths.auth.signIn : emailOtpViewPaths.auth.emailOtp}`,
+        redirectTo
+      )}
       isDisabled={isPending}
       className={cn(
         buttonVariants({ variant: "tertiary" }),

--- a/packages/heroui/src/components/auth/email-otp/forgot-password-otp.tsx
+++ b/packages/heroui/src/components/auth/email-otp/forgot-password-otp.tsx
@@ -1,3 +1,4 @@
+import { getAuthLinkURL } from "@better-auth-ui/core"
 import {
   type EmailOtpAuthClient,
   useAuth,
@@ -47,8 +48,15 @@ export function ForgotPasswordOtp({
   className,
   variant
 }: ForgotPasswordOtpProps) {
-  const { authClient, basePaths, localization, navigate, plugins, viewPaths } =
-    useAuth()
+  const {
+    authClient,
+    basePaths,
+    localization,
+    navigate,
+    plugins,
+    redirectTo,
+    viewPaths
+  } = useAuth()
   const { localization: emailOtpLocalization } = useAuthPlugin(emailOtpPlugin)
 
   const { fetchOptions, resetFetchOptions } = useFetchOptions()
@@ -125,7 +133,10 @@ export function ForgotPasswordOtp({
         <Description className="text-sm">
           {localization.auth.rememberYourPassword}{" "}
           <Link
-            href={`${basePaths.auth}/${viewPaths.auth.signIn}`}
+            href={getAuthLinkURL(
+              `${basePaths.auth}/${viewPaths.auth.signIn}`,
+              redirectTo
+            )}
             className="text-accent no-underline hover:underline decoration-accent-hover"
           >
             {localization.auth.signIn}

--- a/packages/heroui/src/components/auth/email-otp/reset-password-otp.tsx
+++ b/packages/heroui/src/components/auth/email-otp/reset-password-otp.tsx
@@ -1,3 +1,4 @@
+import { getAuthLinkURL } from "@better-auth-ui/core"
 import {
   type EmailOtpAuthClient,
   useAuth,
@@ -56,6 +57,7 @@ export function ResetPasswordOtp({
     emailAndPassword,
     localization,
     navigate,
+    redirectTo,
     viewPaths
   } = useAuth()
   const { localization: emailOtpLocalization, otpLength } =
@@ -321,7 +323,10 @@ export function ResetPasswordOtp({
         <Description className="text-sm">
           {localization.auth.rememberYourPassword}{" "}
           <Link
-            href={`${basePaths.auth}/${viewPaths.auth.signIn}`}
+            href={getAuthLinkURL(
+              `${basePaths.auth}/${viewPaths.auth.signIn}`,
+              redirectTo
+            )}
             className="text-accent no-underline hover:underline decoration-accent-hover"
           >
             {localization.auth.signIn}

--- a/packages/heroui/src/components/auth/email-otp/verify-email-otp.tsx
+++ b/packages/heroui/src/components/auth/email-otp/verify-email-otp.tsx
@@ -1,3 +1,4 @@
+import { getAuthLinkURL } from "@better-auth-ui/core"
 import {
   type EmailOtpAuthClient,
   useAuth,
@@ -224,7 +225,10 @@ export function VerifyEmailOtp({ className, variant }: VerifyEmailOtpProps) {
         <Description className="text-sm">
           {localization.auth.alreadyVerifiedYourEmail}{" "}
           <Link
-            href={`${basePaths.auth}/${viewPaths.auth.signIn}`}
+            href={getAuthLinkURL(
+              `${basePaths.auth}/${viewPaths.auth.signIn}`,
+              redirectTo
+            )}
             className="text-accent no-underline hover:underline decoration-accent-hover"
           >
             {localization.auth.signIn}

--- a/packages/heroui/src/components/auth/forgot-password.tsx
+++ b/packages/heroui/src/components/auth/forgot-password.tsx
@@ -1,3 +1,4 @@
+import { getViewURL } from "@better-auth-ui/core"
 import {
   useAuth,
   useFetchOptions,
@@ -69,7 +70,11 @@ export function ForgotPassword({ className, variant }: ForgotPasswordProps) {
     const formData = new FormData(e.currentTarget)
     requestPasswordReset({
       email: formData.get("email") as string,
-      redirectTo: `${baseURL}${basePaths.auth}/${viewPaths.auth.resetPassword}`,
+      redirectTo: getViewURL(
+        baseURL,
+        basePaths.auth,
+        viewPaths.auth.resetPassword
+      ),
       fetchOptions
     })
   }

--- a/packages/heroui/src/components/auth/reset-link-sent.tsx
+++ b/packages/heroui/src/components/auth/reset-link-sent.tsx
@@ -1,3 +1,4 @@
+import { getAuthLinkURL } from "@better-auth-ui/core"
 import { useAuth } from "@better-auth-ui/react"
 import {
   Card,
@@ -32,7 +33,7 @@ export type ResetLinkSentProps = {
  * @returns The reset-link-sent card React element
  */
 export function ResetLinkSent({ className, variant }: ResetLinkSentProps) {
-  const { basePaths, localization, viewPaths } = useAuth()
+  const { basePaths, localization, redirectTo, viewPaths } = useAuth()
 
   const isHydrated = useIsHydrated()
   const [email, setEmail] = useState(
@@ -68,7 +69,10 @@ export function ResetLinkSent({ className, variant }: ResetLinkSentProps) {
         <Description className="text-sm">
           {localization.auth.rememberYourPassword}{" "}
           <Link
-            href={`${basePaths.auth}/${viewPaths.auth.signIn}`}
+            href={getAuthLinkURL(
+              `${basePaths.auth}/${viewPaths.auth.signIn}`,
+              redirectTo
+            )}
             className="text-accent no-underline hover:underline decoration-accent-hover"
           >
             {localization.auth.signIn}

--- a/packages/heroui/src/components/auth/reset-password.tsx
+++ b/packages/heroui/src/components/auth/reset-password.tsx
@@ -1,3 +1,4 @@
+import { getAuthLinkURL } from "@better-auth-ui/core"
 import { useAuth, useResetPassword } from "@better-auth-ui/react"
 import { Eye, EyeSlash } from "@gravity-ui/icons"
 import {
@@ -33,8 +34,9 @@ export function ResetPassword({ className, variant }: ResetPasswordProps) {
     basePaths,
     emailAndPassword,
     localization,
-    viewPaths,
-    navigate
+    navigate,
+    redirectTo,
+    viewPaths
   } = useAuth()
 
   const { mutate: resetPassword, isPending } = useResetPassword(authClient, {
@@ -225,7 +227,10 @@ export function ResetPassword({ className, variant }: ResetPasswordProps) {
         <Description className="text-sm">
           {localization.auth.rememberYourPassword}{" "}
           <Link
-            href={`${basePaths.auth}/${viewPaths.auth.signIn}`}
+            href={getAuthLinkURL(
+              `${basePaths.auth}/${viewPaths.auth.signIn}`,
+              redirectTo
+            )}
             className="text-accent no-underline hover:underline decoration-accent-hover"
           >
             {localization.auth.signIn}

--- a/packages/heroui/src/components/auth/reset-password.tsx
+++ b/packages/heroui/src/components/auth/reset-password.tsx
@@ -38,11 +38,15 @@ export function ResetPassword({ className, variant }: ResetPasswordProps) {
     redirectTo,
     viewPaths
   } = useAuth()
+  const signInURL = getAuthLinkURL(
+    `${basePaths.auth}/${viewPaths.auth.signIn}`,
+    redirectTo
+  )
 
   const { mutate: resetPassword, isPending } = useResetPassword(authClient, {
     onSuccess: () => {
       toast.success(localization.auth.passwordResetSuccess)
-      navigate({ to: `${basePaths.auth}/${viewPaths.auth.signIn}` })
+      navigate({ to: signInURL })
     }
   })
 
@@ -56,14 +60,9 @@ export function ResetPassword({ className, variant }: ResetPasswordProps) {
 
     if (!token) {
       toast.danger(localization.auth.invalidResetPasswordToken)
-      navigate({ to: `${basePaths.auth}/${viewPaths.auth.signIn}` })
+      navigate({ to: signInURL })
     }
-  }, [
-    basePaths.auth,
-    localization.auth.invalidResetPasswordToken,
-    viewPaths.auth.signIn,
-    navigate
-  ])
+  }, [localization.auth.invalidResetPasswordToken, navigate, signInURL])
 
   function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
     e.preventDefault()
@@ -73,7 +72,7 @@ export function ResetPassword({ className, variant }: ResetPasswordProps) {
 
     if (!token) {
       toast.danger(localization.auth.invalidResetPasswordToken)
-      navigate({ to: `${basePaths.auth}/${viewPaths.auth.signIn}` })
+      navigate({ to: signInURL })
       return
     }
 

--- a/packages/heroui/src/components/auth/settings/account/change-email.tsx
+++ b/packages/heroui/src/components/auth/settings/account/change-email.tsx
@@ -1,3 +1,4 @@
+import { getViewURL } from "@better-auth-ui/core"
 import { useAuth, useChangeEmail, useSession } from "@better-auth-ui/react"
 import {
   Button,
@@ -35,7 +36,7 @@ export function ChangeEmail({
   variant,
   ...props
 }: ChangeEmailProps & Omit<CardProps, "children">) {
-  const { authClient, localization, baseURL, viewPaths } = useAuth()
+  const { authClient, basePaths, baseURL, localization, viewPaths } = useAuth()
   const { data: session } = useSession(authClient)
 
   const { mutate: changeEmail, isPending } = useChangeEmail(authClient, {
@@ -48,7 +49,11 @@ export function ChangeEmail({
 
     changeEmail({
       newEmail: formData.get("email") as string,
-      callbackURL: `${baseURL}/${viewPaths.settings.account}`
+      callbackURL: getViewURL(
+        baseURL,
+        basePaths.settings,
+        viewPaths.settings.account
+      )
     })
   }
 

--- a/packages/heroui/src/components/auth/settings/security/change-password.tsx
+++ b/packages/heroui/src/components/auth/settings/security/change-password.tsx
@@ -1,3 +1,4 @@
+import { getViewURL } from "@better-auth-ui/core"
 import {
   useAuth,
   useChangePassword,
@@ -75,7 +76,8 @@ function SetPassword({
   variant,
   ...props
 }: Omit<CardProps, "children">) {
-  const { authClient, localization, plugins } = useAuth()
+  const { authClient, basePaths, baseURL, localization, plugins, viewPaths } =
+    useAuth()
   const { data: session } = useSession(authClient)
   const { fetchOptions, resetFetchOptions } = useFetchOptions()
   const [sentEmail, setSentEmail] = useState("")
@@ -98,7 +100,15 @@ function SetPassword({
 
   const handleSetPassword = () => {
     if (!session?.user.email) return
-    requestPasswordReset({ email: session.user.email, fetchOptions })
+    requestPasswordReset({
+      email: session.user.email,
+      redirectTo: getViewURL(
+        baseURL,
+        basePaths.auth,
+        viewPaths.auth.resetPassword
+      ),
+      fetchOptions
+    })
   }
 
   return (

--- a/packages/heroui/src/components/auth/sign-up.tsx
+++ b/packages/heroui/src/components/auth/sign-up.tsx
@@ -93,7 +93,10 @@ export function SignUp({
         if (emailAndPassword?.requireEmailVerification) {
           sessionStorage.setItem("better-auth-ui.verify-email", email)
           navigate({
-            to: `${basePaths.auth}/${viewPaths.auth.verifyEmail}`
+            to: getAuthLinkURL(
+              `${basePaths.auth}/${viewPaths.auth.verifyEmail}`,
+              redirectTo
+            )
           })
         } else if (onSignUpSuccess) {
           onSignUpSuccess()

--- a/packages/heroui/src/components/auth/sign-up.tsx
+++ b/packages/heroui/src/components/auth/sign-up.tsx
@@ -1,5 +1,6 @@
 import {
   authMutationKeys,
+  getAuthLinkURL,
   parseAdditionalFieldValue
 } from "@better-auth-ui/core"
 import {
@@ -424,7 +425,10 @@ export function SignUp({
         <Description className="text-sm">
           {localization.auth.alreadyHaveAnAccount}{" "}
           <Link
-            href={`${basePaths.auth}/${viewPaths.auth.signIn}`}
+            href={getAuthLinkURL(
+              `${basePaths.auth}/${viewPaths.auth.signIn}`,
+              redirectTo
+            )}
             className="text-accent no-underline hover:underline decoration-accent-hover"
           >
             {localization.auth.signIn}

--- a/packages/heroui/tests/change-email.test.tsx
+++ b/packages/heroui/tests/change-email.test.tsx
@@ -1,0 +1,62 @@
+import { QueryClient } from "@tanstack/react-query"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { AuthProvider } from "../src/components/auth/auth-provider"
+import { ChangeEmail } from "../src/components/auth/settings/account/change-email"
+
+function createMockAuthClient() {
+  const changeEmail = vi.fn(async () => ({ data: null, error: null }))
+
+  return {
+    changeEmail,
+    getSession: async () => ({
+      user: { id: "user-1", email: "old@example.com", name: "User" },
+      session: {}
+    })
+  } as unknown as Parameters<typeof AuthProvider>[0]["authClient"] & {
+    changeEmail: typeof changeEmail
+  }
+}
+
+describe("<ChangeEmail />", () => {
+  it("includes the configured settings base path in its callback URL", async () => {
+    const user = userEvent.setup()
+    const authClient = createMockAuthClient()
+
+    render(
+      <AuthProvider
+        authClient={authClient}
+        basePaths={{ settings: "/profile/" }}
+        baseURL="https://example.com/"
+        navigate={() => {}}
+        queryClient={
+          new QueryClient({
+            defaultOptions: {
+              queries: { retry: false },
+              mutations: { retry: false }
+            }
+          })
+        }
+        viewPaths={{ settings: { account: "/personal/" } }}
+      >
+        <ChangeEmail />
+      </AuthProvider>
+    )
+
+    const email = await screen.findByRole("textbox", { name: /email/i })
+    await user.clear(email)
+    await user.type(email, "new@example.com")
+    await user.click(screen.getByRole("button", { name: /update email/i }))
+
+    await waitFor(() => {
+      expect(authClient.changeEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          callbackURL: "https://example.com/profile/personal",
+          newEmail: "new@example.com"
+        })
+      )
+    })
+  })
+})

--- a/packages/heroui/tests/reset-password.test.tsx
+++ b/packages/heroui/tests/reset-password.test.tsx
@@ -1,0 +1,102 @@
+import { QueryClient } from "@tanstack/react-query"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { AuthProvider } from "../src/components/auth/auth-provider"
+import { ResetPassword } from "../src/components/auth/reset-password"
+
+function createMockAuthClient() {
+  const resetPassword = vi.fn(async () => ({ data: null, error: null }))
+
+  return {
+    resetPassword,
+    useSession: () => ({ data: null, isPending: false, error: null })
+  } as unknown as Parameters<typeof AuthProvider>[0]["authClient"] & {
+    resetPassword: typeof resetPassword
+  }
+}
+
+function renderResetPassword(path: string) {
+  const authClient = createMockAuthClient()
+  const navigate = vi.fn()
+  window.history.pushState({}, "", path)
+
+  return {
+    authClient,
+    navigate,
+    ...render(
+      <AuthProvider
+        authClient={authClient}
+        navigate={navigate}
+        queryClient={
+          new QueryClient({
+            defaultOptions: {
+              queries: { retry: false },
+              mutations: { retry: false }
+            }
+          })
+        }
+      >
+        <ResetPassword />
+      </AuthProvider>
+    )
+  }
+}
+
+afterEach(() => {
+  window.history.pushState({}, "", "/")
+})
+
+describe("<ResetPassword />", () => {
+  const redirectTo = "/projects/acme?tab=members"
+  const encodedRedirectTo = encodeURIComponent(redirectTo)
+  const signInURL = `/auth/sign-in?redirectTo=${encodedRedirectTo}`
+
+  it("preserves the redirect target when the reset token is missing", async () => {
+    const { navigate } = renderResetPassword(
+      `/auth/reset-password?redirectTo=${encodedRedirectTo}`
+    )
+
+    await waitFor(() => {
+      expect(navigate).toHaveBeenCalledWith({ to: signInURL })
+    })
+  })
+
+  it("preserves the redirect target if the token disappears before submit", async () => {
+    const user = userEvent.setup()
+    const { authClient, navigate } = renderResetPassword(
+      `/auth/reset-password?token=reset-token&redirectTo=${encodedRedirectTo}`
+    )
+    window.history.pushState(
+      {},
+      "",
+      `/auth/reset-password?redirectTo=${encodedRedirectTo}`
+    )
+
+    await user.type(screen.getByLabelText("Password"), "new-password")
+    await user.click(screen.getByRole("button", { name: "Reset Password" }))
+
+    expect(authClient.resetPassword).not.toHaveBeenCalled()
+    expect(navigate).toHaveBeenCalledWith({ to: signInURL })
+  })
+
+  it("preserves the redirect target after a successful reset", async () => {
+    const user = userEvent.setup()
+    const { authClient, navigate } = renderResetPassword(
+      `/auth/reset-password?token=reset-token&redirectTo=${encodedRedirectTo}`
+    )
+
+    await user.type(screen.getByLabelText("Password"), "new-password")
+    await user.click(screen.getByRole("button", { name: "Reset Password" }))
+
+    await waitFor(() => {
+      expect(authClient.resetPassword).toHaveBeenCalledWith({
+        fetchOptions: { throw: true },
+        newPassword: "new-password",
+        token: "reset-token"
+      })
+      expect(navigate).toHaveBeenCalledWith({ to: signInURL })
+    })
+  })
+})

--- a/packages/heroui/tests/set-password.test.tsx
+++ b/packages/heroui/tests/set-password.test.tsx
@@ -36,6 +36,8 @@ function renderChangePassword(authClient = createMockAuthClient()) {
     ...render(
       <AuthProvider
         authClient={authClient}
+        basePaths={{ auth: "/login/" }}
+        baseURL="https://example.com/"
         navigate={() => {}}
         queryClient={
           new QueryClient({
@@ -45,6 +47,7 @@ function renderChangePassword(authClient = createMockAuthClient()) {
             }
           })
         }
+        viewPaths={{ auth: { resetPassword: "/new-password/" } }}
       >
         <ChangePassword />
       </AuthProvider>
@@ -67,6 +70,7 @@ describe("<ChangePassword /> without a credential account", () => {
     expect(authClient.requestPasswordReset).toHaveBeenCalledWith(
       expect.objectContaining({
         email: "user@gmail.com",
+        redirectTo: "https://example.com/login/new-password",
         fetchOptions: expect.objectContaining({ throw: true })
       })
     )

--- a/packages/heroui/tests/sign-up.test.tsx
+++ b/packages/heroui/tests/sign-up.test.tsx
@@ -1,7 +1,7 @@
 import { QueryClient } from "@tanstack/react-query"
 import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
-import { describe, expect, it, vi } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { AuthProvider } from "../src/components/auth/auth-provider"
 import { SignUp } from "../src/components/auth/sign-up"
@@ -56,7 +56,52 @@ function renderSignUp(optional: string) {
   )
 }
 
+afterEach(() => {
+  sessionStorage.clear()
+  window.history.pushState({}, "", "/")
+})
+
 describe("<SignUp />", () => {
+  it("preserves the redirect target when continuing to email verification", async () => {
+    const user = userEvent.setup()
+    const navigate = vi.fn()
+    const redirectTo = "/projects/acme?tab=members"
+    window.history.pushState(
+      {},
+      "",
+      `/auth/sign-up?redirectTo=${encodeURIComponent(redirectTo)}`
+    )
+
+    render(
+      <AuthProvider
+        authClient={createMockAuthClient()}
+        emailAndPassword={{ requireEmailVerification: true }}
+        navigate={navigate}
+        queryClient={
+          new QueryClient({
+            defaultOptions: {
+              queries: { retry: false },
+              mutations: { retry: false }
+            }
+          })
+        }
+      >
+        <SignUp />
+      </AuthProvider>
+    )
+
+    await user.type(screen.getByLabelText("Name"), "Ada Lovelace")
+    await user.type(screen.getByLabelText("Email"), "ada@example.com")
+    await user.type(screen.getByLabelText("Password"), "correct horse battery")
+    await user.click(screen.getByRole("button", { name: "Sign Up" }))
+
+    await waitFor(() => {
+      expect(navigate).toHaveBeenCalledWith({
+        to: `/auth/verify-email?redirectTo=${encodeURIComponent(redirectTo)}`
+      })
+    })
+  })
+
   it("labels optional additional fields without marking required fields", () => {
     renderSignUp(" [not required]")
 

--- a/packages/react/src/components/auth/auth-provider.tsx
+++ b/packages/react/src/components/auth/auth-provider.tsx
@@ -53,10 +53,11 @@ export type AuthProviderProps<TAuthClient = AuthClient> = PropsWithChildren<
 /**
  * Provides merged authentication configuration and a resolved React Query client to descendant components.
  *
- * The component merges the provided auth config with the library defaults, updates `redirectTo` from the
- * current URL when the app is hydrated, wires a QueryClient (prop, context, or fallback) and installs an
- * error handler that surfaces query errors via the configured toast. It then supplies the merged config
- * via AuthContext and wraps children with QueryClientProvider.
+ * The component merges the provided auth config with the library defaults,
+ * resolves `redirectTo` from the current URL whenever it is read, wires a
+ * QueryClient (prop, context, or fallback), and installs an error handler that
+ * surfaces query errors via the configured toast. It then supplies the merged
+ * config via AuthContext and wraps children with QueryClientProvider.
  *
  * @returns The children wrapped with AuthContext.Provider and QueryClientProvider configured for auth.
  */
@@ -73,11 +74,18 @@ export function AuthProvider({
     ),
     authClient
   }
+  const configuredRedirectTo = mergedConfig.redirectTo
 
-  mergedConfig.redirectTo =
-    (typeof window !== "undefined" &&
-      new URLSearchParams(window.location.search).get("redirectTo")?.trim()) ||
-    mergedConfig.redirectTo
+  Object.defineProperty(mergedConfig, "redirectTo", {
+    configurable: true,
+    enumerable: true,
+    get: () =>
+      (typeof window !== "undefined" &&
+        new URLSearchParams(window.location.search)
+          .get("redirectTo")
+          ?.trim()) ||
+      configuredRedirectTo
+  })
 
   // Merge plugin-contributed `additionalFields` with user-supplied ones.
   // Plugin order is preserved; user-supplied entries with the same `name`

--- a/packages/react/tests/hooks/use-auth.test.tsx
+++ b/packages/react/tests/hooks/use-auth.test.tsx
@@ -108,6 +108,28 @@ describe("useAuth", () => {
       expect(result.current.redirectTo).toBe("/dashboard")
     })
 
+    it("reads redirectTo from the current URL after client navigation", () => {
+      const wrapper = ({ children }: { children: ReactNode }) => (
+        <AuthProvider
+          authClient={mockAuthClient}
+          redirectTo="/fallback"
+          navigate={() => {}}
+        >
+          {children}
+        </AuthProvider>
+      )
+
+      const { result } = renderHook(() => useAuth(), { wrapper })
+
+      expect(result.current.redirectTo).toBe("/fallback")
+
+      window.history.pushState({}, "", "/auth/sign-in?redirectTo=%2Fdashboard")
+      expect(result.current.redirectTo).toBe("/dashboard")
+
+      window.history.pushState({}, "", "/auth/sign-in")
+      expect(result.current.redirectTo).toBe("/fallback")
+    })
+
     it("should merge nested configurations from AuthProvider", () => {
       const wrapper = ({ children }: { children: ReactNode }) => (
         <AuthProvider

--- a/packages/solid/src/components/auth/auth-link.tsx
+++ b/packages/solid/src/components/auth/auth-link.tsx
@@ -1,0 +1,66 @@
+import type { Component, JSX } from "solid-js"
+import { splitProps } from "solid-js"
+import { Dynamic } from "solid-js/web"
+import { useAuth } from "../../lib/auth-provider"
+
+export type AuthLinkProps = Omit<
+  JSX.AnchorHTMLAttributes<HTMLAnchorElement>,
+  "href" | "onClick"
+> & {
+  href: string
+  onClick?: JSX.EventHandler<HTMLAnchorElement, MouseEvent>
+}
+
+declare module "@better-auth-ui/core" {
+  interface AuthConfig {
+    /**
+     * Optional component used to render internal navigation links.
+     *
+     * When omitted, `AuthLink` renders a native anchor.
+     */
+    Link?: Component<AuthLinkProps>
+  }
+}
+
+/**
+ * Render an internal auth link with the router adapter configured on
+ * `AuthProvider`, falling back to a native anchor.
+ */
+export function AuthLink(props: AuthLinkProps) {
+  const auth = useAuth()
+  const [local, linkProps] = splitProps(props, ["children", "href", "onClick"])
+  const Link = auth.Link ?? "a"
+
+  const handleClick: JSX.EventHandler<HTMLAnchorElement, MouseEvent> = (
+    event
+  ) => {
+    local.onClick?.(event)
+
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey ||
+      linkProps.target === "_blank" ||
+      linkProps.download
+    ) {
+      return
+    }
+
+    event.preventDefault()
+    auth.navigate({ to: local.href })
+  }
+
+  return (
+    <Dynamic
+      component={Link}
+      {...linkProps}
+      href={local.href}
+      onClick={auth.Link ? local.onClick : handleClick}
+    >
+      {local.children}
+    </Dynamic>
+  )
+}

--- a/packages/solid/src/components/auth/auth-link.tsx
+++ b/packages/solid/src/components/auth/auth-link.tsx
@@ -43,7 +43,7 @@ export function AuthLink(props: AuthLinkProps) {
       event.ctrlKey ||
       event.shiftKey ||
       event.altKey ||
-      linkProps.target === "_blank" ||
+      (linkProps.target && linkProps.target !== "_self") ||
       linkProps.download
     ) {
       return

--- a/packages/solid/src/index.ts
+++ b/packages/solid/src/index.ts
@@ -1,4 +1,5 @@
 export { createAuthClient } from "better-auth/solid"
+export * from "./components/auth/auth-link"
 export * from "./components/auth/auth-prompts"
 export * from "./hooks/auth/use-authenticate"
 export * from "./hooks/auth/use-last-login-method"

--- a/packages/solid/src/lib/auth-config.ts
+++ b/packages/solid/src/lib/auth-config.ts
@@ -35,8 +35,13 @@ export function resolveAuthConfig(
       }
     }
   } as AuthConfig)
+  const configuredRedirectTo = mergedConfig.redirectTo
 
-  mergedConfig.redirectTo = resolveRedirectTo(mergedConfig.redirectTo)
+  Object.defineProperty(mergedConfig, "redirectTo", {
+    configurable: true,
+    enumerable: true,
+    get: () => resolveRedirectTo(configuredRedirectTo)
+  })
   mergedConfig.additionalFields = mergeAdditionalFields(
     mergedConfig.plugins?.flatMap((plugin) => plugin.additionalFields ?? []),
     mergedConfig.additionalFields

--- a/packages/solid/tests/auth-provider-render.test.tsx
+++ b/packages/solid/tests/auth-provider-render.test.tsx
@@ -2,7 +2,13 @@ import { basePaths, createAuthPlugin } from "@better-auth-ui/core"
 import { renderToString } from "solid-js/web"
 import { describe, expect, it, vi } from "vitest"
 
-import { AuthProvider, useAuth, useAuthPlugin } from "../src"
+import {
+  AuthLink,
+  type AuthLinkProps,
+  AuthProvider,
+  useAuth,
+  useAuthPlugin
+} from "../src"
 
 function AuthConsumer() {
   const auth = useAuth()
@@ -45,5 +51,23 @@ describe("Solid AuthProvider render context", () => {
     ))
 
     expect(resolvedPlugin).toBe(registeredPlugin)
+  })
+
+  it("renders internal links through the configured router adapter", () => {
+    const authClient = { getSession: vi.fn() }
+    let receivedHref: string | undefined
+
+    function Link(props: AuthLinkProps) {
+      receivedHref = props.href
+      return props.children
+    }
+
+    renderToString(() => (
+      <AuthProvider authClient={authClient as never} Link={Link}>
+        {() => <AuthLink href="/login/sign-in">Sign in</AuthLink>}
+      </AuthProvider>
+    ))
+
+    expect(receivedHref).toBe("/login/sign-in")
   })
 })

--- a/packages/solid/tests/behavior-parity.test.ts
+++ b/packages/solid/tests/behavior-parity.test.ts
@@ -92,6 +92,7 @@ describe("Solid auth behavior parity", () => {
     const config = resolveAuthConfig({
       authClient,
       navigate,
+      redirectTo: "/fallback",
       viewPaths: { auth: { signIn: "custom-sign-in" } }
     } as never)
 
@@ -102,6 +103,12 @@ describe("Solid auth behavior parity", () => {
     })
     expect(config.viewPaths.settings).toEqual(viewPaths.settings)
     expect(config.redirectTo).toBe("/settings")
+
+    window.location.search = "?redirectTo=%2Fdashboard"
+    expect(config.redirectTo).toBe("/dashboard")
+
+    window.location.search = ""
+    expect(config.redirectTo).toBe("/fallback")
     expect(config.navigate).toBe(navigate)
   })
 


### PR DESCRIPTION
## Summary

- build email-change and password-reset callbacks from the configured origin, base path, and view path across HeroUI, shadcn, Base UI, Next.js, docs, and Solid
- keep `redirectTo` query parameters current after client-side navigation in React and Solid
- route Solid auth links through a configurable router adapter so custom auth and settings base paths work everywhere
- preserve the Base UI theme-toggle override during source synchronization
- include the regenerated Fumadocs TypeScript caches

## Validation

- `bun nx run-many -t test -p @better-auth-ui/core @better-auth-ui/react @better-auth-ui/solid @better-auth-ui/heroui start-solid-zaidan-example --outputStyle=static`
- `bun nx run-many -t typecheck -p @better-auth-ui/core @better-auth-ui/react @better-auth-ui/solid @better-auth-ui/heroui start-shadcn-example start-shadcn-baseui-example next-shadcn-example start-solid-zaidan-example docs --outputStyle=static`
- `bun nx run-many -t build -p @better-auth-ui/core @better-auth-ui/react @better-auth-ui/solid @better-auth-ui/heroui start-shadcn-example start-shadcn-baseui-example next-shadcn-example start-solid-zaidan-example docs --outputStyle=static`
- `bun nx run-many -t lint -p docs next-shadcn-example --outputStyle=static`
- `bunx biome check .`

Fixes #396
Fixes #447
Related to #395


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added auth-aware Solid `AuthLink` navigation and updated example UIs to use it.
  * Introduced shared helpers for composing view/callback and auth redirect URLs with `redirectTo`.
* **Bug Fixes**
  * Redirect URLs now consistently respect configured base/view paths and preserve the current `redirectTo` value across auth flows (password, email, phone, magic link, and settings).
* **Tests**
  * Expanded coverage for `redirectTo` URL composition and added/updated navigation assertions across examples and UI components.
* **Chores**
  * Updated consumer sync to treat the theme toggle as a base UI override.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->